### PR TITLE
minor updates related to v_mean subroutine

### DIFF
--- a/src/kpp.f
+++ b/src/kpp.f
@@ -392,11 +392,9 @@ c            write (543,12) k,cm3(k,1),cm3(k,2)
 
 c Init calc of v_mean and henry
 c initialize all variables also for box run
-!      call v_mean_a  (t,nf)
 !     call henry_a (t,p,nf) ! jjb second argument (p) not used
       call henry_a (t,nf)   ! jjb removed
       call st_coeff_a
-!      call v_mean_t  (t,nf)
 !     call henry_t (t,p,nf) ! jjb second argument (p) not used
       call henry_t (t,nf)   ! jjb removed
       call st_coeff_t

--- a/src/str.f
+++ b/src/str.f
@@ -5014,7 +5014,6 @@ c update total liquid water [kg/m^3]
 !         enddo
          stop 'jjb: box version has to be updated'
          call v_mean (t(:nf))
-         !call v_mean_a  (t,nf)  
 !        call henry_a (t,p,nf) ! jjb second argument (p) not used
          call henry_a (t,nf)   ! jjb removed
 !        call fast_k_mt_a(freep,cw,fa_lse,nf) ! jjb cw now passed as a CB
@@ -5030,7 +5029,6 @@ c update total liquid water [kg/m^3]
          if (cm(3,n_bl).gt.0.) xph3 = 1.
          if (cm(4,n_bl).gt.0.) xph4 = 1.
          if (xph3.eq.1..or.xph4.eq.1.) then
-            !call v_mean_t  (t,nf) 
 !           call henry_t (t,p,nf) ! jjb second argument (p) not used
             call henry_t (t,nf)   ! jjb removed
 !           call fast_k_mt_t(freep,cw,fa_lse,nf) ! jjb cw now passed as a CB

--- a/src/str.f
+++ b/src/str.f
@@ -83,6 +83,7 @@
      &     nka,
      &     nkt,
      &     nphrxn,
+     &     nmax_chem_aer,
      &     mbs
 
       implicit double precision (a-h,o-z)
@@ -200,7 +201,7 @@
       if (chem) call profc (dt,mic)
 ! allocate arrays and initialise vmean
       if (chem) call v_mean_init
-      if (chem) call v_mean (t(:nf))
+      if (chem) call v_mean (t(:nmax_chem_aer))
 
 
 ! Continue the initialisation, both cases
@@ -4949,6 +4950,7 @@ c update total liquid water [kg/m^3]
      &     n,
      &     nrlay,
      &     nkc,
+     &     nmax_chem_aer,
      &     mbs
 
       implicit double precision (a-h,o-z)
@@ -5013,7 +5015,7 @@ c update total liquid water [kg/m^3]
 !            enddo
 !         enddo
          stop 'jjb: box version has to be updated'
-         call v_mean (t(:nf))
+         call v_mean (t(:nmax_chem_aer))
 !        call henry_a (t,p,nf) ! jjb second argument (p) not used
          call henry_a (t,nf)   ! jjb removed
 !        call fast_k_mt_a(freep,cw,fa_lse,nf) ! jjb cw now passed as a CB


### PR DESCRIPTION
1) Add header and comments for v_mean and v_mean_init subroutines,
2) Minor cleaning of old (commented) call to previous versions v_mean_a and v_mean_t
3) Improve consistency of the upper limit (vertical dimension) of vmean calculation, using only nmax_chem_aer (=nf currently) parameter