### PR TITLE
Minor corrections following the previous changes.

### DIFF
--- a/param/param_jjb1
+++ b/param/param_jjb1
@@ -61,4 +61,7 @@ else
     echo "The executable does not exist, installation aborted" && exit 1
 fi
 
-echo " -- End of param script -- "
+# Move output files in OUTDIR
+mv fort.* *.out *.nc rst*.dat $OUTDIR
+
+echo " -- End of param script (end of the run) -- "

--- a/src/activity.f90
+++ b/src/activity.f90
@@ -389,8 +389,8 @@ subroutine calpar(Iflag,NC,NA,T,b0,b1,C0,C1,omega,xs)
   integer,       intent(in) :: Iflag(NC,NA)
 
 ! Array arguments with intent(out):
-  real(kind=dp), dimension(nc,na), intent(out) :: b0, b1
-  real(kind=dp), dimension(nc,na), intent(out) :: c0, c1
+  real(kind=dp), intent(out) :: b0(nc,na), b1(nc,na)
+  real(kind=dp), intent(out) :: c0(nc,na), c1(nc,na)
 
   real(kind=dp), intent(out) :: omega(nc,na)
   real(kind=dp), intent(out) :: xs(11)

--- a/src/kpp.f
+++ b/src/kpp.f
@@ -150,11 +150,11 @@ c initialization of chemistry module
 ! ------------------------------------------------------------
 ! initial mixing ratio of gas phase species in nmol mol-1 (=ppb)
       ! mixing ratio at ground
-      write (60,6010) 
+      write (60,6010)
  6010 format (6x,'initial gas concentration at the surface [ppb]')
       write (60,6020) (s1_init_grd(j),j=1,j1)
       ! mixing ratio at top
-      write (60,6012) 
+      write (60,6012)
  6012 format (6x,'initial gas concentration at the top [ppb]')
       write (60,6020) (s1_init_top(j),j=1,j1)
 ! emission rates of gas phase species in molecules/cm**2/s
@@ -264,15 +264,15 @@ c initial radical concentrations in mol/m**3(air)
       !if (iod) xiod=1.
 
 
-c define crystallization and deliquescene rel humidities (Seinfeld and Pandis, 
+c define crystallization and deliquescene rel humidities (Seinfeld and Pandis,
 c Fig 9.4, p. 519)
-c usually several cloud cycles have been made therefore sulfate aerosol is 
-c usually shrinking; for sea salt crystallization point is used as well, because 
+c usually several cloud cycles have been made therefore sulfate aerosol is
+c usually shrinking; for sea salt crystallization point is used as well, because
 c sea salt particle were produced as droplets and shrank, but did not get "dry"
 c if rel hum is below crys rH in FT, and it's getting more humid then the deli rH
 c has to be taken for reactivation of aerosol chemistry
-      xcryssulf= 0.4  ! crystallization humities 
-      xcrysss  = 0.42  
+      xcryssulf= 0.4  ! crystallization humities
+      xcrysss  = 0.42
       xdelisulf= 0.7  ! assumed based on mixing between different salts - should be
                       ! calculated explicitly if this starts to be critical (ie for
                       ! non-marine cases)
@@ -287,25 +287,25 @@ c layers in which rH > xcrystallization
             cloudt(kc,k)=.true.
          enddo
       enddo
-c initial loading of aerosols with nh3,so4,fe(3),mn(2) (x0=mole/particle) 
+c initial loading of aerosols with nh3,so4,fe(3),mn(2) (x0=mole/particle)
 c watch out: sa1 is defined as sa1(..,j2,..) but addressed in j6 (=ion, sion1) terms
 c            except for DOM which is in sl1 (therefore it is in j2)!!
       do ia=1,nka
 cc ocean aerosol: particles with rn(ia)<.5 mum: 32% (NH4)2SO4, 64% NH4HSO4, 4% NH4NO3
 c ocean aerosol: particles with rn(ia)<.5 mum: 34% (NH4)2SO4, 65.6% NH4HSO4, 0.4% NH4NO3
-         if (rn(ia).lt.0.5) then  
-            x0=en(ia)*1.d-03*fcs(ia)/xmol3(ia) 
+         if (rn(ia).lt.0.5) then
+            x0=en(ia)*1.d-03*fcs(ia)/xmol3(ia)
 c            sa1(ia,13)=x0*0.04 !NO3-
             sa1(ia,13)=x0*0.004 !NO3-
             sa1(ia,2)=x0*1.34   !NH4+
-            sa1(ia,8)=x0*0.34   !SO4=    
-            sa1(ia,19)=x0*0.656 !HSO4-    
+            sa1(ia,8)=x0*0.34   !SO4=
+            sa1(ia,19)=x0*0.656 !HSO4-
 c larger particles: pure nacl
          else
-            x0=en(ia)*1.d-03*fcs(ia)/xmol3(ia) 
+            x0=en(ia)*1.d-03*fcs(ia)/xmol3(ia)
 c sea salt particle
 c x0 = mol / particle
-c all the xiii are scaled to the sum of all negative ions in seawater, 
+c all the xiii are scaled to the sum of all negative ions in seawater,
 c Na+ is the sum of all positive ions; to get the correct molar ratios of
 c Cl- or Br- to Na+, the lumped Na+ has to be multiplied by 0.806
             xso42m=0.0485
@@ -315,7 +315,7 @@ c Cl- or Br- to Na+, the lumped Na+ has to be multiplied by 0.806
             xim   =7.4d-8/.545*xiod
             xio3m =2.64d-7/.545*xiod
             xclm  =1-(xso42m+xhco3m+xno3m+xbrm+xim+xio3m)
-            sa1(ia, 8)=xso42m*x0    ! SO4=    
+            sa1(ia, 8)=xso42m*x0    ! SO4=
             sa1(ia, 9)=xhco3m*x0    ! HCO3-
             sa1(ia,13)=xno3m*x0     ! NO3-
             sa1(ia,14)=xclm*x0      ! Cl-
@@ -358,7 +358,7 @@ c      write (60,6020) (sa1(ia,j2-j3+5),ia=1,nka)
  6060 format (6x,'sa1(nka,24)')
       write (60,6020) (sa1(ia,24),ia=1,nka)
 
-c levels for  rate output 
+c levels for  rate output
       il(1) =  5
       if (box) il(1)=n_bl
       il(2) = 15
@@ -523,7 +523,7 @@ c dry deposition velocities for gas phase
 
 c calculate rate for surface reaction OH + Cl-
 !      call gamma_surf (box,n_bl) ! jjb not used
-      
+
 c calculate rates for DRY heterogeneous reactions
       call dry_cw_rc (nmax)
       call dry_rates_g (t,p,nmax)
@@ -594,30 +594,30 @@ c experimentally determined values (from MOCCA)
       alpha(ind_O3,k) =  2.0D-03
       alpha(ind_O2,k) =
      &     1./(1.+1./(1./(1./1.0d-2 -1.)*exp(2000.d0*TCORR))) ! 06.04.00
-c      alpha(ind_OH,k) =  4.0D-03 
+c      alpha(ind_OH,k) =  4.0D-03
       alpha(ind_OH,k) =  1.0D-2
-      alpha(ind_HO2,k) =  2.0D-01 
-c      alpha(ind_H2O2,k) =  9.1D-02 
+      alpha(ind_HO2,k) =  2.0D-01
+c      alpha(ind_H2O2,k) =  9.1D-02
       alpha(ind_H2O2,k) =
-     &     1./(exp(-26.d3/RT+107.8456/RGAS) + 1.) 
-      alpha(ind_NO,k) =  5.0D-05 
-      alpha(ind_NO2,k) =  1.5D-03 
-c      alpha(ind_NO3,k) =  2.5D-03 
-      alpha(ind_NO3,k) =  4.0D-02 
-c      alpha(ind_N2O5,k) =  2.7D-02 
+     &     1./(exp(-26.d3/RT+107.8456/RGAS) + 1.)
+      alpha(ind_NO,k) =  5.0D-05
+      alpha(ind_NO2,k) =  1.5D-03
+c      alpha(ind_NO3,k) =  2.5D-03
+      alpha(ind_NO3,k) =  4.0D-02
+c      alpha(ind_N2O5,k) =  2.7D-02
       alpha(ind_N2O5,k) =  1.0D-01
-      alpha(ind_HONO,k) =  4.0D-02 
-c      alpha(ind_HNO3,k) =  8.6D-02 
+      alpha(ind_HONO,k) =  4.0D-02
+c      alpha(ind_HNO3,k) =  8.6D-02
       alpha(ind_HNO3,k) =  5.0D-01
-      alpha(ind_NH3,k) =  6.0D-02 
+      alpha(ind_NH3,k) =  6.0D-02
       alpha(ind_MO2,k) =
      &     1./(1.+1./(1./(1./1.0d-2-1.)*exp(2000.d0*TCORR)))   ! 06.04.00
-c+      alpha(ind_ROOH,k) =  5.5D-03 
-c      alpha(ind_ROOH,k) =  5.5D-03 
+c+      alpha(ind_ROOH,k) =  5.5D-03
+c      alpha(ind_ROOH,k) =  5.5D-03
 c      alpha(ind_ROOH,k) =  0.01
       alpha(ind_ROOH,k)=
      &     1./(exp(-6.5D3*C_o_RT+32.5*C_o_R)+1.)
-      alpha(ind_HCHO,k) =  4.0D-02 
+      alpha(ind_HCHO,k) =  4.0D-02
 c      alpha(ind_ACO2,k) =  1.8D-02  !HCOOH
       alpha(ind_ACO2,k)=
      &     1./(exp(-7.9E3*C_o_RT+34.9*C_o_R)+1.)   !HCOOH
@@ -626,33 +626,33 @@ c      alpha(ind_ACO2,k) =  1.8D-02  !HCOOH
       alpha(ind_C2H5OH,k) =  4.8D-02  ! at 273 K, Jayne et al., 1991
       alpha(ind_CO2,k) =
      &     1./(1.+1./(1./(1./1.0d-2-1.)*exp(2000.d0*TCORR))) !06.04.00
-c      alpha(ind_HCl,k) =  7.2D-02 
+c      alpha(ind_HCl,k) =  7.2D-02
 c      alpha(ind_HCl,k) = 0.1
       alpha(ind_HCl,k) =  1./(exp(-3.072d3/t(k) + 1.283d1)+1.) !T=290: 0.096, T=270: 0.190
-c      alpha(ind_HOCl,k) =  7.2D-02 
+c      alpha(ind_HOCl,k) =  7.2D-02
 c      alpha(ind_HOCl,k) =  5.0D-01 see below
-      alpha(ind_ClNO3,k) =  1.0D-01 
-c      alpha(ind_Cl2,k) =  5.5D-02 
+      alpha(ind_ClNO3,k) =  1.0D-01
+c      alpha(ind_Cl2,k) =  5.5D-02
       alpha(ind_Cl2,k) =
      &     1./(exp(-1.3D4*C_o_RT+50.*C_o_R)+1.)
-c      alpha(ind_HBr,k) =  7.2D-02 
+c      alpha(ind_HBr,k) =  7.2D-02
 c      alpha(ind_HBr,k) = 0.05
       alpha(ind_HBr,k) = 1./(exp(-3.94d3/t(k) + 1.664d1) + 1.) !T=290K: 0.017, T=270K: 0.130
       alpha(ind_HOBr,k) =  6.0D-01  ! #1077
       alpha(ind_HOCl,k) = alpha(ind_HOBr,k)
-      alpha(ind_BrNO3,k) =  8.0D-01 
-c      alpha(ind_Br2,k) =  5.5D-02 
+      alpha(ind_BrNO3,k) =  8.0D-01
+c      alpha(ind_Br2,k) =  5.5D-02
       alpha(ind_Br2,k) =
      &     1./(exp(-1.3D4*C_o_RT+50.*C_o_R)+1.)
-c      alpha(ind_BrCl,k) =  5.5D-02 
+c      alpha(ind_BrCl,k) =  5.5D-02
       alpha(ind_BrCl,k) = 0.33 !#840 alpha(ind_Cl2,k)
-      alpha(ind_SO2,k) =  1.1D-01 
+      alpha(ind_SO2,k) =  1.1D-01
 c      alpha(ind_CH3SO3H,k) =  8.4D-02
       alpha(ind_CH3SO3H,k)=
      &     1./(exp(-3.50D3*C_o_RT+16.7*C_o_R)
      &     +1.) ! MSA, #955
       alpha(ind_DMS,k) = 1.0D-2 ! assumed
-c      alpha(ind_DMSO,k) =  5.6D-02 
+c      alpha(ind_DMSO,k) =  5.6D-02
       alpha(ind_DMSO,k) =1./(exp(-5.12D3*C_o_RT+23.1*C_o_R)
      &     +1.)  ! #955
       alpha(ind_DMSO2,k) =
@@ -662,10 +662,10 @@ c      alpha(ind_DMSO,k) =  5.6D-02
 c no uptake of other DMS products like CH3SCH2OO, CH3S, CH3SO, CH3SO2, CH3SO3
       alpha(ind_INO3,k) = 1./(1.+1./(1./(1./1.0d-1 -1.)*
      &                   exp(2000.d0*TCORR)))!06.04.00
-cc      alpha(ind_HOI,k) =  7.2D-02 
-cc      alpha(ind_HOI,k) =  5.0D-01 
-      alpha(ind_HOI,k) = alpha(ind_HOBr,k) 
-cc      alpha(ind_HI,k) =  7.2D-02 
+cc      alpha(ind_HOI,k) =  7.2D-02
+cc      alpha(ind_HOI,k) =  5.0D-01
+      alpha(ind_HOI,k) = alpha(ind_HOBr,k)
+cc      alpha(ind_HI,k) =  7.2D-02
       alpha(ind_HI,k) =  1./(exp(-4.13d3/t(k) + 1.715d1)+1.)
       alpha(ind_I2,k) =  1./(1.+1./(1./(1./ 1.0d-2 -1.)*
      &                 exp(2000.d0*TCORR)))!06.04.00
@@ -770,30 +770,30 @@ c experimentally determined values (from MOCCA)
       alpha(ind_O3,k) =  2.0D-03
       alpha(ind_O2,k) =
      &     1./(1.+1./(1./(1./1.0d-2 -1.)*exp(2000.d0*TCORR))) ! 06.04.00
-c      alpha(ind_OH,k) =  4.0D-03 
+c      alpha(ind_OH,k) =  4.0D-03
       alpha(ind_OH,k) =  1.0D-2
-      alpha(ind_HO2,k) =  2.0D-01 
-c      alpha(ind_H2O2,k) =  9.1D-02 
+      alpha(ind_HO2,k) =  2.0D-01
+c      alpha(ind_H2O2,k) =  9.1D-02
       alpha(ind_H2O2,k) =
-     &     1./(exp(-26.d3/RT+107.8456/RGAS) + 1.) 
-      alpha(ind_NO,k) =  5.0D-05 
-      alpha(ind_NO2,k) =  1.5D-03 
-c      alpha(ind_NO3,k) =  2.5D-03 
-      alpha(ind_NO3,k) =  4.0D-02 
-c      alpha(ind_N2O5,k) =  2.7D-02 
+     &     1./(exp(-26.d3/RT+107.8456/RGAS) + 1.)
+      alpha(ind_NO,k) =  5.0D-05
+      alpha(ind_NO2,k) =  1.5D-03
+c      alpha(ind_NO3,k) =  2.5D-03
+      alpha(ind_NO3,k) =  4.0D-02
+c      alpha(ind_N2O5,k) =  2.7D-02
       alpha(ind_N2O5,k) =  1.0D-01
-      alpha(ind_HONO,k) =  4.0D-02 
-c      alpha(ind_HNO3,k) =  8.6D-02 
+      alpha(ind_HONO,k) =  4.0D-02
+c      alpha(ind_HNO3,k) =  8.6D-02
       alpha(ind_HNO3,k) =  5.0D-01
-      alpha(ind_NH3,k) =  6.0D-02 
+      alpha(ind_NH3,k) =  6.0D-02
       alpha(ind_MO2,k) =
      &     1./(1.+1./(1./(1./1.0d-2-1.)*exp(2000.d0*TCORR)))   ! 06.04.00
-c+      alpha(ind_ROOH,k) =  5.5D-03 
-c      alpha(ind_ROOH,k) =  5.5D-03 
+c+      alpha(ind_ROOH,k) =  5.5D-03
+c      alpha(ind_ROOH,k) =  5.5D-03
 c      alpha(ind_ROOH,k) =  0.01
       alpha(ind_ROOH,k)=
      &     1./(exp(-6.5D3*C_o_RT+32.5*C_o_R)+1.)
-      alpha(ind_HCHO,k) =  4.0D-02 
+      alpha(ind_HCHO,k) =  4.0D-02
 c      alpha(ind_ACO2,k) =  1.8D-02  !HCOOH
       alpha(ind_ACO2,k)=
      &     1./(exp(-7.9E3*C_o_RT+34.9*C_o_R)+1.)   !HCOOH
@@ -802,33 +802,33 @@ c      alpha(ind_ACO2,k) =  1.8D-02  !HCOOH
       alpha(ind_C2H5OH,k) =  4.8D-02  ! at 273 K, Jayne et al., 1991
       alpha(ind_CO2,k) =
      &     1./(1.+1./(1./(1./1.0d-2-1.)*exp(2000.d0*TCORR))) !06.04.00
-c      alpha(ind_HCl,k) =  7.2D-02 
+c      alpha(ind_HCl,k) =  7.2D-02
 c      alpha(ind_HCl,k) = 0.1
       alpha(ind_HCl,k) =  1./(exp(-3.072d3/t(k) + 1.283d1)+1.) !T=290: 0.096, T=270: 0.190
-c      alpha(ind_HOCl,k) =  7.2D-02 
+c      alpha(ind_HOCl,k) =  7.2D-02
 c      alpha(ind_HOCl,k) =  5.0D-01 see below
-      alpha(ind_ClNO3,k) =  1.0D-01 
-c      alpha(ind_Cl2,k) =  5.5D-02 
+      alpha(ind_ClNO3,k) =  1.0D-01
+c      alpha(ind_Cl2,k) =  5.5D-02
       alpha(ind_Cl2,k) =
      &     1./(exp(-1.3D4*C_o_RT+50.*C_o_R)+1.)
-c      alpha(ind_HBr,k) =  7.2D-02 
+c      alpha(ind_HBr,k) =  7.2D-02
 c      alpha(ind_HBr,k) = 0.05
       alpha(ind_HBr,k) = 1./(exp(-3.94d3/t(k) + 1.664d1) + 1.) !T=290K: 0.017, T=270K: 0.130
       alpha(ind_HOBr,k) =  6.0D-01  ! #1077
       alpha(ind_HOCl,k) = alpha(ind_HOBr,k)
-      alpha(ind_BrNO3,k) =  8.0D-01 
-c      alpha(ind_Br2,k) =  5.5D-02 
+      alpha(ind_BrNO3,k) =  8.0D-01
+c      alpha(ind_Br2,k) =  5.5D-02
       alpha(ind_Br2,k) =
      &     1./(exp(-1.3D4*C_o_RT+50.*C_o_R)+1.)
-c      alpha(ind_BrCl,k) =  5.5D-02 
+c      alpha(ind_BrCl,k) =  5.5D-02
       alpha(ind_BrCl,k) = 0.33 !#840 alpha(ind_Cl2,k)
-      alpha(ind_SO2,k) =  1.1D-01 
+      alpha(ind_SO2,k) =  1.1D-01
 c      alpha(ind_CH3SO3H,k) =  8.4D-02
       alpha(ind_CH3SO3H,k)=
      &     1./(exp(-3.50D3*C_o_RT+16.7*C_o_R)
      &     +1.) ! MSA, #955
       alpha(ind_DMS,k) = 1.0D-2 ! assumed
-c      alpha(ind_DMSO,k) =  5.6D-02 
+c      alpha(ind_DMSO,k) =  5.6D-02
       alpha(ind_DMSO,k) =1./(exp(-5.12D3*C_o_RT+23.1*C_o_R)
      &     +1.)  ! #955
       alpha(ind_DMSO2,k) =
@@ -838,10 +838,10 @@ c      alpha(ind_DMSO,k) =  5.6D-02
 c no uptake of other DMS products like CH3SCH2OO, CH3S, CH3SO, CH3SO2, CH3SO3
       alpha(ind_INO3,k) = 1./(1.+1./(1./(1./1.0d-1 -1.)*
      &                   exp(2000.d0*TCORR)))!06.04.00
-cc      alpha(ind_HOI,k) =  7.2D-02 
-cc      alpha(ind_HOI,k) =  5.0D-01 
-      alpha(ind_HOI,k) = alpha(ind_HOBr,k) 
-cc      alpha(ind_HI,k) =  7.2D-02 
+cc      alpha(ind_HOI,k) =  7.2D-02
+cc      alpha(ind_HOI,k) =  5.0D-01
+      alpha(ind_HOI,k) = alpha(ind_HOBr,k)
+cc      alpha(ind_HI,k) =  7.2D-02
       alpha(ind_HI,k) =  1./(exp(-4.13d3/t(k) + 1.715d1)+1.)
       alpha(ind_I2,k) =  1./(1.+1./(1./(1./ 1.0d-2 -1.)*
      &                 exp(2000.d0*TCORR)))!06.04.00
@@ -904,7 +904,7 @@ c
 !    SR v_mean_init is called during initialisation:
 !      - by SR initc (no restart case)
 !      - by SR str=main (restart case)
-      
+
 ! Input :
 ! -----
 !    - chemical species molar masses have been imported from the user defined files ('gas_species.csv')
@@ -932,7 +932,7 @@ c
 !
 ! 04-Jan-2017   Josue Bock   First version
 !
-      
+
 ! == End of header =============================================================
 
 ! Declarations :
@@ -961,15 +961,19 @@ c
 ! Imported Parameters:
      &     nmax_chem_aer
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
 ! Local scalars:
       integer :: jtot
       integer :: jspec
-      double precision :: const_fact
+      real (kind=dp) :: const_fact
 
 ! Local arrays:
-      double precision :: sqrt_mass (j1 + j5 + j4)
+      real (kind=dp) :: sqrt_mass (j1 + j5 + j4)
 
 ! == End of declarations =======================================================
 
@@ -1016,7 +1020,7 @@ c
 !      - during the run
 !        - by SR liq_parm
 !        - by SR box_update (which is call during time integration, but actually calls v_mean only during initialisation)
-      
+
 ! Input :
 ! -----
 !    - vmean_init has been computed by SR v_mean_init during initialisation
@@ -1079,16 +1083,20 @@ c
 ! Imported Parameters:
      &     nmax_chem_aer
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
 ! Subroutine arguments
 ! Array arguments with intent(in):
-      double precision, intent(in) :: temperature (nmax_chem_aer)
+      real (kind=dp), intent(in) :: temperature (nmax_chem_aer)
 ! Local scalars:
       integer :: jtot
       integer :: j,k
 ! Local arrays:
-      double precision :: sqrtt(nmax_chem_aer)
+      real (kind=dp) :: sqrtt(nmax_chem_aer)
 
 ! == End of declarations =======================================================
 
@@ -1131,7 +1139,7 @@ c in equilibrium: XXXaq = k_H^cp * LWC * XXXg
 
       implicit none
 
-      include 'tot_Parameters.h'    !additional common blocks and other definitions   
+      include 'tot_Parameters.h'    !additional common blocks and other definitions
 
       double precision, intent(in) :: tt(n) ! temperature array
       integer         , intent(in) :: nmaxf ! max layer index where henry has to be computed
@@ -1161,7 +1169,7 @@ c      func3(a0,b0,k0)=a0*exp(b0*((1/tt(k0))-3.3557d-3))*0.082*tt(k0)
       henry(:,:) = 0.d0
 
       do k=1,nmaxf
-         
+
 c         henry(ind_H2SO4,k)=4.1d-12   !???
          henry(ind_H2SO4,k)=1.d+16    !NIST --> RS_Gmitro_Vermeulen
          henry(ind_CH4,k)=1.3d-3    !RS_Mackay
@@ -1205,7 +1213,7 @@ c explicitly Temp dependent
          ! Tfact = 1/T - 1/Tref  with Tref = 298.15
          ! 1/298.15 = 3.3540d-3
          Tfact = 1.d0/tt(k) - 3.3540d-3
-         
+
          henry(ind_NO,k)=func3(1.9d-03,1480.d0) !RS_Lide
 c         henry(ind_NO2,k)=func3(1.d-02,2500.d0) !RS_Chameides
          henry(ind_NO2,k)=func3(6.4d-03,2500.d0) !RS_MOCCA
@@ -1232,7 +1240,7 @@ c         henry(ind_HCl,k)=func3(1.17d0,9001.d0) !RS_MOCCA
          henry(ind_HCl,k)=func3(2.d0/1.7d0,9001.d0) !RS_MOCCA_exakt
 c         henry(ind_R3N2,k)=func3(1.d0,5450.d0) !RS_kames: propyl nitrate
          henry(ind_NO3,k)=func3(2.d0,2000.d0) !RS_MOCCA
-         henry(ind_DMS,k)=func3(4.8d-1,3100.d0) !RS_deBruyn 
+         henry(ind_DMS,k)=func3(4.8d-1,3100.d0) !RS_deBruyn
 c         henry(ind_DMSO,k)=5.d4     !RS_MOCCA
          henry(ind_DMSO,k)=func3(5.d4,6425.d0)     !RS_MOCCA 06.04.00
          henry(ind_DMSO2,k)= 1.d+16    !DMSO2=H2SO4, assumed
@@ -1289,7 +1297,7 @@ c         henry(ind_RBr,k)=func3()
 c         henry(ind_SPAN,k)=func3()
 
 
-c include HERE call to get effective henry coeffs (if needed), 
+c include HERE call to get effective henry coeffs (if needed),
 c before inverse k_H are calculated
 c         xCO2=func3(4.3d-7,-919.d0)
 c         x3CO2=xCO2*func3(4.7d-11,-1787.d0)
@@ -1348,7 +1356,7 @@ c in equilibrium: XXXaq = k_H^cp * LWC * XXXg
 
       implicit none
 
-      include 'aer_Parameters.h'    !additional common blocks and other definitions   
+      include 'aer_Parameters.h'    !additional common blocks and other definitions
 
       double precision, intent(in) :: tt(n) ! temperature array
       integer         , intent(in) :: nmaxf ! max layer index where henry has to be computed
@@ -1422,7 +1430,7 @@ c explicitly Temp dependent
          ! Tfact = 1/T - 1/Tref  with Tref = 298.15 K
          ! 1/298.15 = 3.3540d-3
          Tfact = 1.d0/tt(k) - 3.3540d-3
-         
+
          henry(ind_NO,k)=func3(1.9d-03,1480.d0) !RS_Lide
 c         henry(ind_NO2,k)=func3(1.d-02,2500.d0) !RS_Chameides
          henry(ind_NO2,k)=func3(6.4d-03,2500.d0) !RS_MOCCA
@@ -1449,7 +1457,7 @@ c         henry(ind_HCl,k)=func3(1.17d0,9001.d0) !RS_MOCCA
          henry(ind_HCl,k)=func3(2.d0/1.7d0,9001.d0) !RS_MOCCA_exakt
 c         henry(ind_R3N2,k)=func3(1.d0,5450.d0) !RS_kames: propyl nitrate
          henry(ind_NO3,k)=func3(2.d0,2000.d0) !RS_MOCCA
-         henry(ind_DMS,k)=func3(4.8d-1,3100.d0) !RS_deBruyn 
+         henry(ind_DMS,k)=func3(4.8d-1,3100.d0) !RS_deBruyn
 c         henry(ind_DMSO,k)=5.d4     !RS_MOCCA
          henry(ind_DMSO,k)=func3(5.d4,6425.d0)     !RS_MOCCA 06.04.00
          henry(ind_DMSO2,k)= 1.d+16    !DMSO2=H2SO4, assumed
@@ -1505,8 +1513,8 @@ c         henry(ind_RBr,k)=func3()
          henry(ind_SOR,k)=func3(1.5d2,6400.d0) !  same as ethanol
 c         henry(ind_SPAN,k)=func3()
 
-         
-c include HERE call to get effective henry coeffs (if needed), 
+
+c include HERE call to get effective henry coeffs (if needed),
 c before inverse k_H are calculated
 c         xCO2=func3(4.3d-7,-919.d0)
 c         x3CO2=xCO2*func3(4.7d-11,-1787.d0)
@@ -1567,6 +1575,10 @@ c mean radius and LWC for "chemical" particles size bins
      &     nkt,
      &     nkc
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
 ! Subroutine arguments
@@ -1574,58 +1586,58 @@ c mean radius and LWC for "chemical" particles size bins
       integer, intent(in) :: nmaxf ! max index for calculation  ! jjb might add a test on it, error if > n, warning if > nf
 
 ! Local parameters:
-      double precision, parameter :: xpi = 4./3.*pi
+      real (kind=dp), parameter :: xpi = 4./3.*pi
 
-      double precision, parameter :: cwm = 1.d-1 ! Threshold for switching chemistry in bins 1 & 2 ("aerosols")
-      double precision, parameter :: cwmd = 1.d2 ! Threshold for switching chemistry in bins 3 & 4 ("droplets") 
+      real (kind=dp), parameter :: cwm = 1.d-1 ! Threshold for switching chemistry in bins 1 & 2 ("aerosols")
+      real (kind=dp), parameter :: cwmd = 1.d2 ! Threshold for switching chemistry in bins 3 & 4 ("droplets")
                                                  !   here "d" stands for droplets, not dry !
 
 ! Local scalars:
-      double precision :: cm1, cm2, cm3, cm4
-      double precision :: cw1, cw2, cw3, cw4
-      double precision :: rc1, rc2, rc3, rc4
-      double precision :: x0, x1
+      real (kind=dp) :: cm1, cm2, cm3, cm4
+      real (kind=dp) :: cw1, cw2, cw3, cw4
+      real (kind=dp) :: rc1, rc2, rc3, rc4
+      real (kind=dp) :: x0, x1
       integer :: ia, ial, jt ! loop indexes for 2D particle grid
       integer :: k  ! index for grid number in do loops
 
 ! Common blocks:
       common /blck06/ kw(nka),ka
-      integer kw, ka
+      integer :: kw, ka
 
       common /blck11/ rc(nkc,n)
-      double precision rc
+      real (kind=dp) :: rc
 
       common /blck12/ cw(nkc,n),cm(nkc,n)
-      double precision cw, cm
+      real (kind=dp) :: cw, cm
 
       common /blck13/ conv2(nkc,n) ! conversion factor = 1/(1000*cw)
-      double precision conv2
+      real (kind=dp) :: conv2
 
       common /cb50/ enw(nka),ew(nkt),rn(nka),rw(nkt,nka),en(nka), ! only rq and e are used
      &              e(nkt),dew(nkt),rq(nkt,nka)
-      double precision enw, ew, rn, rw, en, e, dew, rq
+      real (kind=dp) :: enw, ew, rn, rw, en, e, dew, rq
 
       common /cb52/ ff(nkt,nka,n),fsum(n),nar(n) ! only ff is used
-      double precision ff, fsum
-      integer nar
+      real (kind=dp) :: ff, fsum
+      integer :: nar
 
       common /cb54/ xm1(n),xm2(n),feu(n),dfddt(n),xm1a(n),xm2a(n) ! only feu is used
       real(kind=dp) :: xm1, xm2, feu, dfddt, xm1a, xm2a
 
       common /kpp_l1/ cloud(nkc,n)
-      logical cloud
+      logical :: cloud
 
       common /kpp_crys/ xcryssulf,xcrysss,xdelisulf,xdeliss
-      double precision xcryssulf,xcrysss,xdelisulf,xdeliss
+      real (kind=dp) :: xcryssulf,xcrysss,xdelisulf,xdeliss
 
       common /kinv_i/ kinv
       integer :: kinv
 
       common /nucfeed/ ifeed
-      integer ifeed
+      integer :: ifeed
 
 c rc(nkc,n): mean radius of droplets in m
-c cw(nkc,n): LWC in given radius range in m^3(aq)g/m^3(air) 
+c cw(nkc,n): LWC in given radius range in m^3(aq)g/m^3(air)
 c      cwm=1.d-05
 
 ! Define lower bound depending on nucleation settings
@@ -1756,7 +1768,7 @@ c                       --> m^3(wat)/m^3(air):10^-3
 
             if ( (cw2.ge.cwm) .and.
      &          ((cloud(2,k).and.feu(k).ge.xcrysss).or.    ! same comments
-     &           (feu(k).ge.xdeliss)) ) then 
+     &           (feu(k).ge.xdeliss)) ) then
                cm(2,k)=cm2*1.d-3
                conv2(2,k) = 1.d9/cw2
             else
@@ -1984,7 +1996,7 @@ c sedimentation velocity:
 !                  if (l.eq.1) vt(kc,k)=4.*3.1415927/(3.*cw(kc,k))*xx1
                   if (l.eq.1) vt(kc,k)=4.*pi/(3.*cw(kc,k))*xx1
                end if
-            enddo !l 
+            enddo !l
 
             goto 1002
 
@@ -1995,8 +2007,8 @@ c define summation limits (1) ---
             if (kc.eq.1.or.kc.eq.3) then
                if (ifeed.eq.2) then
                  iia_0=2
-               else    
-                 iia_0=1 
+               else
+                 iia_0=1
                endif
                iia_e=ka
             endif
@@ -2027,7 +2039,7 @@ c sedimentation velocity:
 
  1002       continue
          enddo                  ! kc
-         
+
  1000 continue  !k
 
       end subroutine fast_k_mt_t
@@ -2072,7 +2084,7 @@ c but no mean values used (like in SR k_mt_a/t) but integrated values
      &     dp
 
 
- 
+
       implicit double precision (a-h,o-z)
 
       include 'aer_Parameters.h' !additional common blocks and other definitions
@@ -2157,7 +2169,7 @@ c loop over the species to be exchanged between gas and aqueous phase---
                end do
 
                if(rad_k2m_a(jspec) /= lex(l)) then
-                  
+
                   if(trim(SPC_NAMES(lex(l))) == 'O2') then
                      jspec = j1+j5+1
                   else
@@ -2180,8 +2192,8 @@ c define summation limits (1) ---
                if (kc.eq.1) then
                   if (ifeed.eq.2) then
                     iia_0=2
-                  else    
-                    iia_0=1 
+                  else
+                    iia_0=1
                   endif
                   iia_e=ka
                endif
@@ -2234,7 +2246,7 @@ c sedimentation velocity:
 !                  if (l.eq.1) vt(kc,k)=4.*3.1415927/(3.*cw(kc,k))*xx1
                   if (l.eq.1) vt(kc,k)=4.*pi/(3.*cw(kc,k))*xx1
                end if
-            enddo !l 
+            enddo !l
 
             goto 1002
 
@@ -2245,8 +2257,8 @@ c define summation limits (1) ---
             if (kc.eq.1) then
                if (ifeed.eq.2) then
                  iia_0=2
-               else    
-                 iia_0=1 
+               else
+                 iia_0=1
                endif
                iia_e=ka
             endif
@@ -2278,7 +2290,7 @@ c sedimentation velocity:
 
  1002       continue
          enddo                  ! kc
-         
+
  1000 continue                  !k
 
 
@@ -2301,7 +2313,7 @@ c
 c equilibrium constant (see MOCCA)
 c xkef: forward
 c xkeb: backward
-c activity coefficients included via xgamma 
+c activity coefficients included via xgamma
 c acidity constants Ka = XXXaf/XXXab [mol/l];
 c and other equilibrium constants (f=forward, b=backward reaction);
 c converted to [mol/m3(air)];
@@ -2316,13 +2328,13 @@ c absolute values are chosen arbitrarily to ensure fast equilibration;
 
       implicit double precision (a-h,o-z)
 
-      include 'tot_Parameters.h' !additional common blocks and other definitions          
+      include 'tot_Parameters.h' !additional common blocks and other definitions
 
       common /blck13/ conv2(nkc,n) ! conversion factor = 1/(1000*cw)
       common /kpp_ltot/ henry(NSPEC,nf),xkmt(nf,nkc,NSPEC),
      &     xkef(nf,nkc,NSPEC),xkeb(nf,nkc,NSPEC)
 !     common /kpp_mol/ cm(nf,nkc),xgamma(nf,j6,nkc) ! jjb updated
-      common /kpp_mol/ xgamma(nf,j6,nkc) 
+      common /kpp_mol/ xgamma(nf,j6,nkc)
 !     dimension cw(nf,nkc),tt(n) ! jjb cw removed from argument list
       dimension tt(n)
 
@@ -2341,7 +2353,7 @@ c            if (cw(k,kc).gt.0.) then  !cm is switch now
 !            if (cv2.eq.0.) xsw=0. ! jjb no need to compute all the xkef & xkeb which will be 0. !
             if (cv2.gt.0.) then ! but still better than initialising all NSPEC list !
 
-c absolute values of back- and forward reactions are choosen arbitrarily to 
+c absolute values of back- and forward reactions are choosen arbitrarily to
 c ensure a quick (but numerically stable) equilibrium
 c if illogical error messages arise, try fiddling with the absolute values
 c of equilibrium reactions
@@ -2359,9 +2371,9 @@ c            xkef(k,kc,ind_HO2) = xsw*2.d5  !Chameides '84
      &           1.0D4*cv2*xgamma(k,1,kc)*xgamma(k,16,kc)
 
 c            xkef(k,kc,ind_CO2) = xsw*funa(4.3d3,-913.d0,k)
-c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2   
+c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
             xkef(k,kc,ind_CO2) = xsw*funa(4.3d-2,-913.d0,k)
-            xkeb(k,kc,ind_CO2) = 1.0D5*cv2*xgamma(k,1,kc)*xgamma(k,9,kc)   
+            xkeb(k,kc,ind_CO2) = 1.0D5*cv2*xgamma(k,1,kc)*xgamma(k,9,kc)
 
             xkef(k,kc,ind_HONO) = xsw*funa(5.1d+3,-1260.d0,k)
             xkeb(k,kc,ind_HONO) =
@@ -2374,11 +2386,11 @@ c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
             xkef(k,kc,ind_HNO4) = xsw*2.0D3
             xkeb(k,kc,ind_HNO4) = 2.0D8 * cv2
 
-            xkef(k,kc,ind_NH3) = xsw*funa(1.7d5,-4325.d0,k) 
+            xkef(k,kc,ind_NH3) = xsw*funa(1.7d5,-4325.d0,k)
             xkeb(k,kc,ind_NH3) =
      &           1.0D10* cv2*xgamma(k,3,kc)*xgamma(k,2,kc)
 
-            xkef(k,kc,ind_HSO3ml1) = xsw*funa(6.0d2,1120.d0,k) 
+            xkef(k,kc,ind_HSO3ml1) = xsw*funa(6.0d2,1120.d0,k)
      &           *xgamma(k,5,kc)
             xkeb(k,kc,ind_HSO3ml1) = 1.0D10* cv2*xgamma(k,1,kc)
      &           *xgamma(k,6,kc)
@@ -2406,14 +2418,14 @@ c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
             xkef(k,kc,ind_Cl2ml1) = xsw*5.2d4*xgamma(k,15,kc)    !Chameides '84
             xkeb(k,kc,ind_Cl2ml1) =  1.d10*cv2*xgamma(k,14,kc)
 
-c            xkef(k,kc,ind_Cl2) = 1.1D-3   
-c            xkeb(k,kc,ind_Cl2) = 2.1D2* cv2 
+c            xkef(k,kc,ind_Cl2) = 1.1D-3
+c            xkeb(k,kc,ind_Cl2) = 2.1D2* cv2
 
-            xkef(k,kc,ind_HOCl) = xsw*3.2D2   
+            xkef(k,kc,ind_HOCl) = xsw*3.2D2
             xkeb(k,kc,ind_HOCl) =
      &           1.0D10*cv2*xgamma(k,1,kc)*xgamma(k,22,kc)
 
-            xkef(k,kc,ind_HBr) = xsw*1.0D13   
+            xkef(k,kc,ind_HBr) = xsw*1.0D13
             xkeb(k,kc,ind_HBr) =
      &           1.0D4* cv2*xgamma(k,1,kc)*xgamma(k,24,kc)
 
@@ -2426,24 +2438,24 @@ c            xkeb(k,kc,ind_Cl2) = 2.1D2* cv2
             xkeb(k,kc,ind_HOBr) =
      &           1.0D10*cv2*xgamma(k,1,kc)*xgamma(k,26,kc)
 
-            xkef(k,kc,ind_BrCl2ml1) = funa(5.d9,1143.d0,k) * cv2  
+            xkef(k,kc,ind_BrCl2ml1) = funa(5.d9,1143.d0,k) * cv2
      &           *xgamma(k,14,kc) !#894
             xkeb(k,kc,ind_BrCl2ml1) = xsw*1.3D9   *xgamma(k,28,kc)
 c no activities used, they "cancel out"
-            xkef(k,kc,ind_Br2Clml1) = 5.d9 * cv2!*xgamma(k,24,kc) !if original equilibrium 
-            xkeb(k,kc,ind_Br2Clml1) = xsw*2.8D5!*xgamma(k,29,kc)  !       -"-  
+            xkef(k,kc,ind_Br2Clml1) = 5.d9 * cv2!*xgamma(k,24,kc) !if original equilibrium
+            xkeb(k,kc,ind_Br2Clml1) = xsw*2.8D5!*xgamma(k,29,kc)  !       -"-
             xkef(k,kc,ind_Br2l1) = 5.d9 * cv2!*xgamma(k,14,kc)    !if original equilibrium
-            xkeb(k,kc,ind_Br2l1) = xsw*3.85D9!*xgamma(k,29,kc)    !       -"- 
+            xkeb(k,kc,ind_Br2l1) = xsw*3.85D9!*xgamma(k,29,kc)    !       -"-
             xkef(k,kc,ind_ICl) = 1.0D11  * cv2 *xgamma(k,14,kc)
             xkeb(k,kc,ind_ICl) = xsw*1.3D9   *xgamma(k,37,kc)
             xkef(k,kc,ind_IBr) = 1.0D11  * cv2  *xgamma(k,24,kc)
             xkeb(k,kc,ind_IBr) = xsw*3.5D8  *xgamma(k,38,kc)
 c new (speculative) ICl <--> IBr equilibria, assumed to yield the same
-c ICl/IBr ratio as in the BrCl <--> Br2 eqilibria (BrCl/Br2) 
-c no activities used, they are not known!! 11.04.01 
+c ICl/IBr ratio as in the BrCl <--> Br2 eqilibria (BrCl/Br2)
+c no activities used, they are not known!! 11.04.01
            xkef(k,kc,ind_IClBrml1) = 5.d9 * cv2!*xgamma(k,24,kc)
            xkeb(k,kc,ind_IClBrml1) = xsw*2.8D5!*xgamma(k,29,kc)
-           xkef(k,kc,ind_I2) = 5.d9 * cv2!*xgamma(k,14,kc)    
+           xkef(k,kc,ind_I2) = 5.d9 * cv2!*xgamma(k,14,kc)
            xkeb(k,kc,ind_I2) = xsw*3.85D9!*xgamma(k,29,kc)
 !            xkef(k,kc,ind_HIO2) = xsw*2.0D3
 !            xkeb(k,kc,ind_HIO2) = 2.0D9 * cv2
@@ -2469,7 +2481,7 @@ c            xkeb(k,kc,ind_HgCl2l1)    = xsw * 1.d8
 c            xkef(k,kc,ind_HgCl3ml1)   = 6.7d8 * cv2             ! #4174, K_eq = 6.7d0
 c            xkeb(k,kc,ind_HgCl3ml1)   = xsw * 1.d8
 c            xkef(k,kc,ind_HgCl42ml1)  = 1.3d9 * cv2             ! #4174, K_eq = 1.3d1
-c            xkeb(k,kc,ind_HgCl42ml1)  = xsw * 1.d8 
+c            xkeb(k,kc,ind_HgCl42ml1)  = xsw * 1.d8
 c            xkef(k,kc,ind_HgOHBrl1)   = 2.69d14 * cv2            ! #4158, assumed
 c            xkeb(k,kc,ind_HgOHBrl1)   = xsw * 1.d7
 c            xkef(k,kc,ind_HgBrpl1)    = 1.1d14 * cv2             ! #4174, K_eq = 1.1d9
@@ -2516,13 +2528,13 @@ c absolute values are chosen arbitrarily to ensure fast equilibration;
 
       implicit double precision (a-h,o-z)
 
-      include 'aer_Parameters.h' !additional common blocks and other definitions          
+      include 'aer_Parameters.h' !additional common blocks and other definitions
 
       common /blck13/ conv2(nkc,n) ! conversion factor = 1/(1000*cw)
       common /kpp_laer/ henry(NSPEC,nf),xkmt(nf,nkc,NSPEC),
      &     xkef(nf,nkc,NSPEC),xkeb(nf,nkc,NSPEC)
 !     common /kpp_mol/ cm(nf,nkc),xgamma(nf,j6,nkc) ! jjb updated
-      common /kpp_mol/ xgamma(nf,j6,nkc) 
+      common /kpp_mol/ xgamma(nf,j6,nkc)
 !     dimension cw(nf,nkc),tt(n) ! jjb cw removed from argument list
       dimension tt(n)
 
@@ -2541,7 +2553,7 @@ c            if (cw(k,kc).gt.0.) then !cm is switch now
 !           if (cv2.eq.0.) xsw=0. ! jjb no need to compute all the xkef & xkeb which will be 0. !
             if (cv2.gt.0.) then ! but still better than initialising all NSPEC list !
 
-c absolute values of back- and forward reactions are choosen arbitrarily to 
+c absolute values of back- and forward reactions are choosen arbitrarily to
 c ensure a quick (but numerically stable) equilibrium
 c if illogical error messages arise, try fiddling with the absolute values
 c of equilibrium reactions
@@ -2557,12 +2569,12 @@ c            xkef(k,kc,ind_HO2) = xsw*2.d5  !Chameides '84
 
             xkef(k,kc,ind_ACO2) = xsw*1.8D0
             xkeb(k,kc,ind_ACO2) =
-     &           1.0D4*cv2*xgamma(k,1,kc)*xgamma(k,16,kc)   
+     &           1.0D4*cv2*xgamma(k,1,kc)*xgamma(k,16,kc)
 
 c            xkef(k,kc,ind_CO2) = xsw*funa(4.3d3,-913.d0,k)
-c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2   
+c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
             xkef(k,kc,ind_CO2) = xsw*funa(4.3d-2,-913.d0,k)
-            xkeb(k,kc,ind_CO2) = 1.0D5*cv2*xgamma(k,1,kc)*xgamma(k,9,kc)  
+            xkeb(k,kc,ind_CO2) = 1.0D5*cv2*xgamma(k,1,kc)*xgamma(k,9,kc)
 
             xkef(k,kc,ind_HONO) = xsw*funa(5.1d+3,-1260.d0,k)
             xkeb(k,kc,ind_HONO) =
@@ -2570,12 +2582,12 @@ c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
 
             xkef(k,kc,ind_HNO3) = xsw*funa(1.54d+10,8700.d0,k)
             xkeb(k,kc,ind_HNO3) =
-     &           1.0D9*cv2*xgamma(k,1,kc)*xgamma(k,13,kc)  
+     &           1.0D9*cv2*xgamma(k,1,kc)*xgamma(k,13,kc)
 
             xkef(k,kc,ind_HNO4) = xsw*2.0D3
             xkeb(k,kc,ind_HNO4) = 2.0D8 * cv2
 
-            xkef(k,kc,ind_NH3) = xsw*funa(1.7d5,-4325.d0,k) 
+            xkef(k,kc,ind_NH3) = xsw*funa(1.7d5,-4325.d0,k)
             xkeb(k,kc,ind_NH3) =
      &           1.0D10* cv2*xgamma(k,3,kc)*xgamma(k,2,kc)
 
@@ -2588,7 +2600,7 @@ c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
             xkeb(k,kc,ind_H2SO4)=
      &           1.0d9* cv2*xgamma(k,1,kc)*xgamma(k,19,kc)
 
-            xkef(k,kc,ind_HSO4ml1) = xsw*funa(1.02d+6,2720.d0,k) 
+            xkef(k,kc,ind_HSO4ml1) = xsw*funa(1.02d+6,2720.d0,k)
      &           *xgamma(k,19,kc)
             xkeb(k,kc,ind_HSO4ml1)=
      &           1.0D8*cv2*xgamma(k,1,kc)*xgamma(k,8,kc)
@@ -2607,14 +2619,14 @@ c            xkeb(k,kc,ind_CO2) = 1.0D10* cv2
             xkef(k,kc,ind_Cl2ml1) = xsw*5.2d4*xgamma(k,15,kc)    !Chameides '84
             xkeb(k,kc,ind_Cl2ml1) =  1.d10*cv2*xgamma(k,14,kc)
 
-c            xkef(k,kc,ind_Cl2) = 1.1D-3   
-c            xkeb(k,kc,ind_Cl2) = 2.1D2* cv2 
+c            xkef(k,kc,ind_Cl2) = 1.1D-3
+c            xkeb(k,kc,ind_Cl2) = 2.1D2* cv2
 
-            xkef(k,kc,ind_HOCl) = xsw*3.2D2   
+            xkef(k,kc,ind_HOCl) = xsw*3.2D2
             xkeb(k,kc,ind_HOCl) =
      &           1.0D10*cv2*xgamma(k,1,kc)*xgamma(k,22,kc)
 
-            xkef(k,kc,ind_HBr) = xsw*1.0D13   
+            xkef(k,kc,ind_HBr) = xsw*1.0D13
             xkeb(k,kc,ind_HBr) =
      &           1.0D4* cv2*xgamma(k,1,kc)*xgamma(k,24,kc)
 
@@ -2627,12 +2639,12 @@ c            xkeb(k,kc,ind_Cl2) = 2.1D2* cv2
             xkeb(k,kc,ind_HOBr) =
      &           1.0D10*cv2*xgamma(k,1,kc)*xgamma(k,26,kc)
 
-            xkef(k,kc,ind_BrCl2ml1) = funa(5.d9,1143.d0,k) * cv2 
+            xkef(k,kc,ind_BrCl2ml1) = funa(5.d9,1143.d0,k) * cv2
      &           *xgamma(k,14,kc)
             xkeb(k,kc,ind_BrCl2ml1) = xsw*1.3D9    *xgamma(k,28,kc)
 c no activities used, they "cancel out"
-            xkef(k,kc,ind_Br2Clml1) = 5.d9 * cv2!*xgamma(k,24,kc) !if original equilibrium 
-            xkeb(k,kc,ind_Br2Clml1) = xsw*2.8D5!*xgamma(k,29,kc)  !       -"-  
+            xkef(k,kc,ind_Br2Clml1) = 5.d9 * cv2!*xgamma(k,24,kc) !if original equilibrium
+            xkeb(k,kc,ind_Br2Clml1) = xsw*2.8D5!*xgamma(k,29,kc)  !       -"-
             xkef(k,kc,ind_Br2l1) = 5.d9 * cv2 !*xgamma(k,14,kc)   !if original equilibrium
             xkeb(k,kc,ind_Br2l1) = xsw*3.85D9!*xgamma(k,29,kc)    !       -"-
             xkef(k,kc,ind_ICl) = 1.0D11  * cv2 *xgamma(k,14,kc)
@@ -2640,11 +2652,11 @@ c no activities used, they "cancel out"
             xkef(k,kc,ind_IBr) = 1.0D11  * cv2  *xgamma(k,24,kc)
             xkeb(k,kc,ind_IBr) = xsw*3.5D8  *xgamma(k,38,kc)
 c new (speculative) ICl <--> IBr equilibria, assumed to yield the same
-c ICl/IBr ratio as in the BrCl <--> Br2 eqilibria (BrCl/Br2) 
-c no activities used, they are not known!! 11.04.01 
+c ICl/IBr ratio as in the BrCl <--> Br2 eqilibria (BrCl/Br2)
+c no activities used, they are not known!! 11.04.01
            xkef(k,kc,ind_IClBrml1) = 5.d9 * cv2!*xgamma(k,24,kc)
            xkeb(k,kc,ind_IClBrml1) = xsw*2.8D5!*xgamma(k,29,kc)
-           xkef(k,kc,ind_I2) = 5.d9 * cv2!*xgamma(k,14,kc)    
+           xkef(k,kc,ind_I2) = 5.d9 * cv2!*xgamma(k,14,kc)
            xkeb(k,kc,ind_I2) = xsw*3.85D9!*xgamma(k,29,kc)
 !            xkef(k,kc,ind_HIO2) = xsw*2.0D3
 !            xkeb(k,kc,ind_HIO2) = 2.0D9 * cv2
@@ -2670,7 +2682,7 @@ c            xkeb(k,kc,ind_HgCl2l1)    = xsw * 1.d8
 c            xkef(k,kc,ind_HgCl3ml1)   = 6.7d8 * cv2             ! #4174, K_eq = 6.7d0
 c            xkeb(k,kc,ind_HgCl3ml1)   = xsw * 1.d8
 c            xkef(k,kc,ind_HgCl42ml1)  = 1.3d9 * cv2             ! #4174, K_eq = 1.3d1
-c            xkeb(k,kc,ind_HgCl42ml1)  = xsw * 1.d8 
+c            xkeb(k,kc,ind_HgCl42ml1)  = xsw * 1.d8
 c            xkef(k,kc,ind_HgOHBrl1)   = 2.69d14 * cv2            ! #4158, assumed
 c            xkeb(k,kc,ind_HgOHBrl1)   = xsw * 1.d7
 c            xkef(k,kc,ind_HgBrpl1)    = 1.1d14 * cv2             ! #4174, K_eq = 1.1d9
@@ -2729,7 +2741,7 @@ c the nkc size bins
 
 c vol2 and vol1 old liquid volume in class (1-nkc) and row/class (1-nkc,1-nka)
 c (um^3/cm^3), used in SR konc to shift moles from aerosol to drop
-c and vice versa. 
+c and vice versa.
 c part_o and part_n old and new part. conc. in row/class (1-nkc,1-nka) (cm^-3)
 
       do k=2,nf
@@ -2738,7 +2750,7 @@ c small (dry) particles
          do ia=1,ka
             dp_1=part_o_a(ia,k)-part_n_a(ia,k)
             dp_3=part_o_d(ia,k)-part_n_d(ia,k)
-            if (dabs(dp_1+dp_3).gt.1.d-10) print 
+            if (dabs(dp_1+dp_3).gt.1.d-10) print
      &           *,'Warning SR konc dp_1 > dp_3',k,ia,dp_1,dp_3
 c search bin that loses moles:
             ii=1
@@ -2746,7 +2758,7 @@ c            if (dp_1.ge.1.d-10) ii=1
             if (dp_3.ge.1.d-10) ii=3
 c no change if number of growing particles is too small:
             xs=1.d0
-            if (dabs(dp_1).lt.1.d-10) xs=0.d0 
+            if (dabs(dp_1).lt.1.d-10) xs=0.d0
 c mol/m^3(air) -1-> mol/l(aq) -2-> mol/m^3(air,row) -3-> mol/part(row)
 c -4-> mol/m^3(air,change,row)
 c mol/m^3(air) -1-> mol/l(aq):
@@ -2755,7 +2767,7 @@ c     mol/m^3(aq)*1.d-3 --> mol/l(aq)
 c mol/l(aq) -2-> mol/m^3(air,row):
 c     mol/l(aq) *vol1_@(ia,k)*1.d-9 = mol/m^3(air,row)
 c mol/m^3(air,row) -3-> mol/part(row):
-c     mol/m^3(air,row)*1.d-6 cm^3(air,row)/part = mol/part(row) 
+c     mol/m^3(air,row)*1.d-6 cm^3(air,row)/part = mol/part(row)
 c mol/part(row) -4-> mol/m^3(air,change,row):
 c     mol/part(row)*1.d6*part/cm^3(air,row,change) = mol/m^3(air,row,change)
             if (ii.eq.1) then
@@ -2794,7 +2806,7 @@ c large (dry) particles
          do ia=ka+1,nka
             dp_2=part_o_a(ia,k)-part_n_a(ia,k)
             dp_4=part_o_d(ia,k)-part_n_d(ia,k)
-            if (dabs(dp_2+dp_4).gt.1.d-10) print 
+            if (dabs(dp_2+dp_4).gt.1.d-10) print
      &           *,'Warning SR konc dp_2 > dp_4',k,ia,dp_2,dp_4
             ii=2
 c            if (dp_2.ge.1.d-10) ii=2
@@ -2836,9 +2848,9 @@ c            if (dp_2.ge.1.d-10) ii=2
             enddo
  1112       continue
          enddo ! kc
-         
 
-         
+
+
          do l=1,j2
             if (pntot(3,k).lt.1.d-7) then
                sl1(l,1,k)=sl1(l,1,k)+dmax1(0.d0,sl1(l,3,k))
@@ -2869,7 +2881,7 @@ c
 c-----------------------------------------------------------------------------------
 c
 
-      subroutine init_konc 
+      subroutine init_konc
 c Init loading of aerosols with ions.
 c If rH>0.7 aerosols get activated and liquid chemistry is started.
 c The ions are transported vertically by turbulence and sedimentation
@@ -2906,7 +2918,7 @@ c      double precision ap1o,ap2o,ap2n,apo,apn
       dimension ap(n,nka)
 
 c sa1 in mole/particle; sl1, sion1 in mole m**-3
-c ap total number of aerosols in cm**-3 
+c ap total number of aerosols in cm**-3
 c of sulfate and sea salt aerosol regime
 
       do k=2,n-1
@@ -2931,7 +2943,7 @@ c no3-, nh4+ and so4= due to nucleation scavenging and evaporation
             sion1(13,1,k)=sion1(13,1,k)+ap(k,ia)*sa1(ia,13)*1.d6
             sion1(17,1,k)=sion1(19,1,k)                         !mixing tracer
             sion1(19,1,k)=sion1(19,1,k)+ap(k,ia)*sa1(ia,19)*1.d6
-c NO3-, NH4-, SO4=, HSO4- : j6 used in sion1, sa1 
+c NO3-, NH4-, SO4=, HSO4- : j6 used in sion1, sa1
 c Br-, HCO3-, I-, IO3-, Cl-: j6 used in sion1, sa1
          enddo
          if (sion1(8,1,k).eq.0.) print *,k,'init(so4=)=0'
@@ -3065,7 +3077,7 @@ c  "log" is log10
 c               bb=(0.380-log(rr))/0.65
                bb=(0.380-log10(rr))/0.65
 c               print *,'bb',bb
-               df1=1.373*u10**3.41*rr**(-3.)*(1. + 0.057 *rr**1.05) 
+               df1=1.373*u10**3.41*rr**(-3.)*(1. + 0.057 *rr**1.05)
      &              * 10**(1.19*exp(-bb**2))
 !              if (rr.gt.10..and.rr.lt.75.) df22=8.6d-6*exp(2.08*u10)*
 !    &              rr**(-2)
@@ -3149,15 +3161,14 @@ c use for parameterisation development for global models
 
 ! Local scalars:
       character (len=8),parameter :: fname = 'ppHa.out'
-      integer k
+      integer :: k
 
 ! Local arrays:
-      double precision i0
-      dimension i0(n,25)
+      real (kind=dp) :: i0(n,25)
 
 ! Common blocks:
       common /blck17/ sl1(j2,nkc,n),sion1(j6,nkc,n)
-      double precision sl1, sion1
+      real (kind=dp) :: sl1, sion1
 
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
       real (kind=dp) :: time
@@ -3237,7 +3248,7 @@ c interface between MISTRA and the KPP gas phase chemistry
 ! Imported Parameters:
      &     dp
 
-      implicit double precision (a-h,o-z) 
+      implicit double precision (a-h,o-z)
 !     logical halo,iod,box,new_a,new_c,cloud,short,ros3 ! jjb ros3 removed, thus new_a, new_c & short as well
       logical box,cloud
 
@@ -3273,7 +3284,7 @@ c calculate u0 for prelim photolysis
       rlat=alat*1.745329d-02
       rdec=declin*1.745329d-02
       zeit=lst*3600.+dfloat(lmin-1)*60.
-c      zeit=zeit+dtg  !quite exact, but photolysis rates are calculated in 
+c      zeit=zeit+dtg  !quite exact, but photolysis rates are calculated in
 c greater intervals and variable dtg is known only in the old chemical module
 !      horang=7.272205d-05*zeit-3.1415927
       horang=7.272205d-05*zeit-pi
@@ -3332,7 +3343,7 @@ c photolysis rates
             do i=1,nphrxn
                ph_rat(i)=( photol_j(i,k)+photol_j(i,k-1) ) / 2 ! jjb photol_j defined for levels, not for layers
             enddo
-c end of prelim j rates 
+c end of prelim j rates
          else
             do i=1,nphrxn
                ph_rat(i)=0.
@@ -3398,14 +3409,14 @@ c advection if eulerian view (neula=0), xadv in mol/(mol*day)
          if (neula.eq.0) then
             if (k.le.kinv) then
                do nisp=1,10
-                  if (nspec(nisp).ne.0) 
+                  if (nspec(nisp).ne.0)
      &   s1(nspec(nisp),k)=s1(nspec(nisp),k)+xadv(nisp)*dt_ch*air/86400.
                enddo
             endif
          endif
 
 !         print('(i4,6f4.1)'),k,xliq1,xliq2,xliq3,xliq4,xhet1,xhet2
-c call kpp chemical integrator 
+c call kpp chemical integrator
             if (xliq1.eq.1..or.xliq2.eq.1.) then
                if (xliq3.eq.1..or.xliq4.eq.1.) then
 c gas + aerosol + cloud
@@ -3427,7 +3438,7 @@ c                  print *,k," tot ",tkpp,dt_ch
 !     & ,cloud(4,k)
 
                else
-c gas + aerosol               
+c gas + aerosol
 c                  print *,k," aer ",tkpp,dt_ch
 !                 call aer_drive (tkpp,dt_ch,k,cvv1,cvv2,xhal,
 !    &                 xiod,xliq1,xliq2,xhet1,xhet2,air,co,h2o) ! jjb working version
@@ -3442,9 +3453,9 @@ c                  print *,k," aer ",tkpp,dt_ch
 !         print *,'xhet1-2=',xhet1,xhet2
 !         print *,'cloud(1-4,k)=',cloud(1,k),cloud(2,k),cloud(3,k)
 !     & ,cloud(4,k)
-               endif   
+               endif
             else
-c gas only            
+c gas only
 c het reactions on dry aerosol always on!
                xhet1 = 1.
                xhet2 = 1.
@@ -3478,7 +3489,7 @@ c eliminate negative values
       end subroutine kpp_driver
 
 c
-c----------------------------------------------------- 
+c-----------------------------------------------------
 c
 
       subroutine ionbalance (box,n_bl)
@@ -3518,7 +3529,7 @@ c check ion balance
 
       n_min=1
       n_max=n
-      if (box) then 
+      if (box) then
          n_min=n_bl
          n_max=n_bl
       endif
@@ -3680,29 +3691,33 @@ c to be included in gas-phase mechanism
      &     n,
      &     nkc
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
       include 'gas_Parameters.h'     !additional common blocks and other definitions
-     
-      double precision, intent(in) :: tt(n) ! Temperature
-      double precision, intent(in) :: pp(n) ! Pressure
+
+      real (kind=dp), intent(in) :: tt(n) ! Temperature
+      real (kind=dp), intent(in) :: pp(n) ! Pressure
       integer, intent(in) :: nmax           ! Maximum layer for calculations
 
       integer,parameter :: ndr=4 ! number of species
-      integer idr(ndr)
-      integer k,kc,l
-      double precision x1, FCT
-      double precision xgamma(NSPEC,2),freep(n),vmean(NSPEC,n)
+      integer :: idr(ndr)
+      integer :: k,kc,l
+      real (kind=dp) :: x1, FCT
+      real (kind=dp) :: xgamma(NSPEC,2),freep(n),vmean(NSPEC,n)
       common /blck11/ rcd(nkc,n) ! average particle radius in chemical bin
-      double precision rcd       !  note that in the context of this subroutine, this
+      real (kind=dp) :: rcd      !  note that in the context of this subroutine, this
                                  !  radius is considered as a "dry" radius, thus labeled rcd
 
       common /kpp_dryg/ xkmtd(n,2,NSPEC),henry(n,NSPEC),xeq(n,NSPEC)
-      double precision xkmtd, henry, xeq
+      real (kind=dp) :: xkmtd, henry, xeq
 
-      double precision func, funa, func3 ! local function
-      double precision a,a0,b0           !   and their variables
-      integer k0                         !   ...
+      real (kind=dp) :: func, funa, func3 ! local function
+      real (kind=dp) :: a,a0,b0           !   and their variables
+      integer :: k0                       !   ...
 
 c      data idr/ind_HNO3,ind_N2O5,ind_BrNO3,ind_ClNO3,ind_HOBr/
 !     data idr/ind_HNO3,ind_N2O5,ind_NH3,ind_H2SO4,ind_HCl/     ! jjb HCl is not handled here (but it should be, probably !)
@@ -3726,7 +3741,7 @@ c define gamma's for all species ----
       xgamma(ind_NH3,2)   = 0.05       !Dentener and Crutzen, 1994, #744
       xgamma(ind_H2SO4,1) = 0.1        !estimated from alpha=0.65
       xgamma(ind_H2SO4,2) = 0.1        !estimated from alpha=0.65
-c      xgamma(ind_HCl,1)   = 
+c      xgamma(ind_HCl,1)   =
 c      xgamma(ind_HCl,2)   =
 c      xgamma(ind_BrNO3,1) = 0.3
 c      xgamma(ind_BrNO3,2) = 0.3
@@ -3748,7 +3763,7 @@ c obviously without Pitzer coefficients
          xeq(k,ind_HNO3) = funa(1.54d+10,8700.d0,k)
       enddo
 
-c define inverse Henry's constant 
+c define inverse Henry's constant
       do k=2,nmax
          henry(k,ind_HNO3)=func3(2.5d6/1.5d1,8694.d0,k) !RS_MOCCA_exakt
          FCT=0.0820577*tt(k)
@@ -3776,7 +3791,7 @@ c         vmean(ind_HOI,k)   = func(1.44d-1,k)
 
 c calculate kmt ----
 
-c k_mt=1/(r**2/(3*D_gas)+4*r/(3*v_mean*alpha)) 
+c k_mt=1/(r**2/(3*D_gas)+4*r/(3*v_mean*alpha))
 c if : D_gas=lambda*v_mean/3. then we can rewrite k_mt as:
 c k_mt=v_mean/(r**2/lambda+4*r/(3*alpha))
 
@@ -3787,7 +3802,7 @@ c lambda=freep : mean free path
             do kc=1,2
                if (xgamma(idr(l),kc).gt.0..and.rcd(kc,k).gt.0.) then
                   x1=1./(rcd(kc,k)*(rcd(kc,k)/freep(k)+4./(3.*xgamma
-     &                 (idr(l),kc)))) 
+     &                 (idr(l),kc))))
                else
                   x1=0.
                endif
@@ -3835,7 +3850,7 @@ c xhet1/2 in SR kpp_driver)
       implicit double precision (a-h,o-z)
 
       include 'aer_Parameters.h'     !additional common blocks and other definitions
-     
+
       parameter (ndr=4)
       common /blck11/ rcd(nkc,n)
 !     common /cb50/ enw(nka),ew(nkt),rn(nka),rw(nkt,nka),en(nka),      ! jjb  none of the objects of the common block is used
@@ -3897,7 +3912,7 @@ c obviously without Pitzer coefficients
 
 c calculate kmt ----
 
-c k_mt=1/(r**2/(3*D_gas)+4*r/(3*v_mean*alpha)) 
+c k_mt=1/(r**2/(3*D_gas)+4*r/(3*v_mean*alpha))
 c if : D_gas=lambda*v_mean/3. then we can rewrite k_mt as:
 c k_mt=v_mean/(r**2/lambda+4*r/(3*alpha))
 
@@ -3908,7 +3923,7 @@ c lambda=freep : mean free path
             do kc=1,2
                if (xgamma(idr(l),kc).gt.0..and.rcd(kc,k).gt.0.) then
                   x1=1./(rcd(kc,k)*(rcd(kc,k)/freep(k)+4./(3.*xgamma
-     &                 (idr(l),kc)))) 
+     &                 (idr(l),kc))))
                else
                   x1=0.
                endif
@@ -3930,11 +3945,11 @@ c      enddo
 ! 1102 format ('integrated values')
 
 
-c now the same but with integrated values - - - - - - - - - - - - - - - - 
+c now the same but with integrated values - - - - - - - - - - - - - - - -
 c if working: include smart way of saving CPU time
 c this leads to kmt that are about 10x greater than the bulk approach,
 c nevertheless use bulk as this is what gamma's are determined for, plus
-c it's faster (CPU-wise) 
+c it's faster (CPU-wise)
 
 
 cc loop over vertical grid
@@ -3985,7 +4000,7 @@ c               enddo !ia
 cc k_mt=4*pi/(3*LWC)*sum
 c!               xkmtd(k,kc,idr(l))=4.*3.1415927/(3.*cwd(k,kc))*xk1 ![1/s]
 c               xkmtd(k,kc,idr(l))=4.*pi/(3.*cwd(k,kc))*xk1 ![1/s]
-c            enddo !l 
+c            enddo !l
 c         enddo                  ! kc
 c      enddo                     !k
 
@@ -4025,7 +4040,7 @@ c xhet1/2 in SR kpp_driver)
       implicit double precision (a-h,o-z)
 
       include 'tot_Parameters.h'     !additional common blocks and other definitions
-     
+
       parameter (ndr=4)
       common /blck11/ rcd(nkc,n)
       common /cb53/ theta(n),thetl(n),t(n),talt(n),p(n),rho(n)
@@ -4084,7 +4099,7 @@ c obviously without Pitzer coefficients
 
 c calculate kmt ----
 
-c k_mt=1/(r**2/(3*D_gas)+4*r/(3*v_mean*alpha)) 
+c k_mt=1/(r**2/(3*D_gas)+4*r/(3*v_mean*alpha))
 c if : D_gas=lambda*v_mean/3. then we can rewrite k_mt as:
 c k_mt=v_mean/(r**2/lambda+4*r/(3*alpha))
 
@@ -4095,7 +4110,7 @@ c lambda=freep : mean free path
             do kc=1,2
                if (xgamma(idr(l),kc).gt.0..and.rcd(kc,k).gt.0.) then
                   x1=1./(rcd(kc,k)*(rcd(kc,k)/freep(k)+4./(3.*xgamma
-     &                 (idr(l),kc)))) 
+     &                 (idr(l),kc))))
                else
                   x1=0.
                endif
@@ -4153,12 +4168,12 @@ c
       integer :: jg, k, kc   ! loop indexes for liq. species, vertical layers, liq. bins
       integer :: nmin, nmax  ! lower and upper bounds for calculations
 
-      double precision :: wact
-      double precision :: xip2
+      real (kind=dp) :: wact
+      real (kind=dp) :: xip2
 
 ! Local arrays:
-      double precision :: wa(nkc,nf)
-      double precision :: xip(nkc,nf), xit(nkc,nf)
+      real (kind=dp) :: wa(nkc,nf)
+      real (kind=dp) :: xip(nkc,nf), xit(nkc,nf)
 
 ! Common blocks:
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
@@ -4169,13 +4184,13 @@ c
       real(kind=dp) :: xm1, xm2, feu, dfddt, xm1a, xm2a
 
       common /blck12/ cw(nkc,n),cm(nkc,n)
-      double precision cw, cm
+      real (kind=dp) :: cw, cm
 
       common /blck17/ sl1(j2,nkc,n),sion1(j6,nkc,n)
-      double precision sl1, sion1
+      real (kind=dp) :: sl1, sion1
 
       common /kpp_mol/ xgamma(nf,j6,nkc)
-      double precision xgamma
+      real (kind=dp) :: xgamma
 
 
 ! Initialise lower and upper bounds (in the vertical grid) to do the calculations
@@ -4317,10 +4332,14 @@ c
      &     nf,
      &     nkc
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      common /kpp_mol/ xgamma(nf,j6,nkc) 
-      double precision xgamma
+      common /kpp_mol/ xgamma(nf,j6,nkc)
+      real (kind=dp) xgamma
 
       xgamma(:,:,:) = 1.d0
 
@@ -4469,7 +4488,7 @@ c      hs(33)=henry(ind_RAN1,k)
       hs(51)=henry(ind_INO2,k)
       hs(52)=-1.!henry(ind_INO3,k)
       hs(53)=henry(ind_I2,k)
-      hs(54)=henry(ind_ICl,k) 
+      hs(54)=henry(ind_ICl,k)
       hs(55)=henry(ind_IBr,k)
       hs(56)=henry(ind_CH3I,k)
       hs(57)=henry(ind_CH2I2,k)
@@ -4527,13 +4546,13 @@ c henry constant were already transformed into dimensionless values
       enddo
 c some species dissociate:
       hs(3)=hs(3)*(1. +funa(1.54d+1,8700.d0,k)/sac)
-      hs(4)=hs(4)*(1. + funa(1.7d-5,-4325.d0,k)* 
-     &     sac/funa(1.d-14,-6710.d0,k)) 
-      hs(5)=hs(5)*(1.+ funa(1.7d-2,2090.d0,k)/sac + 
+      hs(4)=hs(4)*(1. + funa(1.7d-5,-4325.d0,k)*
+     &     sac/funa(1.d-14,-6710.d0,k))
+      hs(5)=hs(5)*(1.+ funa(1.7d-2,2090.d0,k)/sac +
      &     funa(1.7d-2,2090.d0,k)*funa(6.0d-8,1120.d0,k) /sac**2)
       hs(6)=hs(6)*(1. + 1.0d+3/sac +
-     &     1.0d+3*funa(1.02d-2,2720.d0,k)/sac**2) 
-      hs(30)=hs(30)*(1. + funa(1.7d6,6896.d0,k)/sac) 
+     &     1.0d+3*funa(1.02d-2,2720.d0,k)/sac**2)
+      hs(30)=hs(30)*(1. + funa(1.7d6,6896.d0,k)/sac)
       hs(38)=hs(38)*(1. + 3.2d-8/sac)
       hs(42)=hs(42)*(1. + 1.d9/sac)
       hs(43)=hs(43)*(1. + funa(2.3d-9,-3091.d0,k)/sac)
@@ -4569,7 +4588,7 @@ c calculate vg from rb and rc for each species
 c      rc_fact=2.54d+4/(tt(k)*ustern)  !Sehmel, 1980
 c      print *,rb_fact,rc_fact
       do i=1,j1
-       if (vm(i).eq.0.) then 
+       if (vm(i).eq.0.) then
          vg(i)=0.
        else
          if (hs(ind_gas(i)).ne.0.) then
@@ -4577,7 +4596,7 @@ c           vg(i)=1./(xra+(rb_fact/(vm(i)**(2./3.)))+(rc_fact/hs(i))) !Sehmel, 1
             vg(i)=1./(xra+(rb_fact/(vm(i)**(2./3.)))+1./(hs(ind_gas(i))*
      &           1.d-5+f0(ind_gas(i))/2000.))  !Wesely, 1989
          else
-c            vg(i)= 1./(xra+(rb_fact/(vm(i)**(2./3.)))+(rc_fact/1.d-7)) !hs=0 => 1/hs -> infinity, 
+c            vg(i)= 1./(xra+(rb_fact/(vm(i)**(2./3.)))+(rc_fact/1.d-7)) !hs=0 => 1/hs -> infinity,
                                                               !here just a value for hstar is chosen
                                                               !to get a small v_dd
             if (f0(ind_gas(i)) > 0.) then
@@ -4588,7 +4607,7 @@ c            vg(i)= 1./(xra+(rb_fact/(vm(i)**(2./3.)))+(rc_fact/1.d-7)) !hs=0 =>
                vg(i)=0.
             end if
          endif
-         if (hs(ind_gas(i)).eq.(-1./FCT)) 
+         if (hs(ind_gas(i)).eq.(-1./FCT))
      &        vg(i)=1./(xra+(rb_fact/(vm(i)**(2./3.)))+.1)     ! "infinite solubility"
       endif
       enddo
@@ -4629,7 +4648,7 @@ c emitted atoms (see SR aer_source) are subtracted
      &     dp
 
 
-      implicit double precision (a-h,o-z) 
+      implicit double precision (a-h,o-z)
       logical cl_out
 
       common /blck17/ sl1(j2,nkc,n),sion1(j6,nkc,n)
@@ -4645,7 +4664,7 @@ c emitted atoms (see SR aer_source) are subtracted
       common /sss/ brsss,clsss,xnasss
 
       if ((lday.eq.0.and.lst.eq.0.and.lmin.le.1).or.lmin/30*30.eq.lmin)
-     &     then       
+     &     then
       cl_out=.false.
       if (nkc_l.gt.2) cl_out=.true.
 c gas phase----------------------------
@@ -4716,23 +4735,23 @@ c atmosphere
      &        2.*sl1(46,1,k)+sl1(47,1,k)+sl1(55,1,k)+sl1(j2-j3+9,1,k)
      &        +sion1(24,1,k)+2.*sion1(25,1,k)+sion1(26,1,k)+
      &    sion1(27,1,k)+sion1(28,1,k)+2.*sion1(29,1,k)+2.*sion1(38,1,k))
-     &        *detw(k) 
+     &        *detw(k)
          bra2=bra2+(sl1(42,2,k)+sl1(43,2,k)+sl1(44,2,k)+sl1(45,2,k)+
      &        2.*sl1(46,2,k)+sl1(47,2,k)+sl1(55,2,k)+sl1(j2-j3+9,2,k)
      &        +sion1(24,2,k)+2.*sion1(25,2,k)+sion1(26,2,k)+
      &    sion1(27,2,k)+sion1(28,2,k)+2.*sion1(29,2,k)+2.*sion1(38,2,k))
-     &        *detw(k) 
+     &        *detw(k)
          if (cl_out) then
          bra3=bra3+(sl1(42,3,k)+sl1(43,3,k)+sl1(44,3,k)+sl1(45,3,k)+
      &        2.*sl1(46,3,k)+sl1(47,3,k)+sl1(55,3,k)+sl1(j2-j3+9,3,k)
      &        +sion1(24,3,k)+2.*sion1(25,3,k)+sion1(26,3,k)+
      &    sion1(27,3,k)+sion1(28,3,k)+2.*sion1(29,3,k)+2.*sion1(38,3,k))
-     &        *detw(k) 
+     &        *detw(k)
          bra4=bra4+(sl1(42,4,k)+sl1(43,4,k)+sl1(44,4,k)+sl1(45,4,k)+
      &        2.*sl1(46,4,k)+sl1(47,4,k)+sl1(55,4,k)+sl1(j2-j3+9,4,k)
      &        +sion1(24,4,k)+2.*sion1(25,4,k)+sion1(26,4,k)+
      &    sion1(27,4,k)+sion1(28,4,k)+2.*sion1(29,4,k)+2.*sion1(38,4,k))
-     &        *detw(k) 
+     &        *detw(k)
          endif
 
          cla1=cla1+(sl1(30,1,k)+sl1(38,1,k)+sl1(39,1,k)+sl1(40,1,k)+
@@ -4818,22 +4837,22 @@ c output
      &     ,err=100)
       write (74,10) lday,lst,lmin
        if (cl_out) then
-        write (74,20) brg, brgd, bra1, bra2, bra1d,bra2d, brsss*detw(1), 
+        write (74,20) brg, brgd, bra1, bra2, bra1d,bra2d, brsss*detw(1),
      &     brg+bra1+bra2+brgd+bra1d+bra2d-brsss*detw(1)
-        write (74,20) brg, brgd, bra3, bra4,bra3d, bra4d, brsss*detw(1), 
+        write (74,20) brg, brgd, bra3, bra4,bra3d, bra4d, brsss*detw(1),
      &     brg+bra3+bra4+brgd+bra3d+bra4d-brsss*detw(1),brg+bra1+bra2+
      &     brgd+bra1d+bra2d+bra3+bra4+brgd+bra3d+bra4d-brsss*detw(1)
-        write (74,25) clg, clgd, cla1, cla2,cla1d, cla2d, clsss*detw(1), 
+        write (74,25) clg, clgd, cla1, cla2,cla1d, cla2d, clsss*detw(1),
      &     clg+cla1+cla2+clgd+cla1d+cla2d-clsss*detw(1)
-        write (74,25) clg, clgd, cla3, cla4,cla3d, cla4d, clsss*detw(1), 
+        write (74,25) clg, clgd, cla3, cla4,cla3d, cla4d, clsss*detw(1),
      &     clg+cla3+cla4+clgd+cla3d+cla4d-clsss*detw(1),clg+cla1+cla2+
      &     clgd+cla1d+cla2d+cla3+cla4+clgd+cla3d+cla4d-clsss*detw(1)
         write (74,30) xnaa2, xnaa2d,xnasss*detw(1),xnaa2+xnaa2d-xnasss*
      &     detw(1)
        else
-        write (74,20) brg, brgd, bra1, bra2, bra1d,bra2d, brsss*detw(1), 
+        write (74,20) brg, brgd, bra1, bra2, bra1d,bra2d, brsss*detw(1),
      &     brg+bra1+bra2+brgd+bra1d+bra2d-brsss*detw(1)
-        write (74,25) clg, clgd, cla1, cla2, cla1d,cla2d, clsss*detw(1), 
+        write (74,25) clg, clgd, cla1, cla2, cla1d,cla2d, clsss*detw(1),
      &     clg+cla1+cla2+clgd+cla1d+cla2d-clsss*detw(1)
         write (74,30) xnaa2, xnaa2d,  xnasss*detw(1), xnaa2+xnaa2d
      &     -xnasss*detw(1)
@@ -4856,7 +4875,7 @@ c----------------------------------------------------------------
 c
 
 
-      subroutine ave_parms (n_bl,nz_box) 
+      subroutine ave_parms (n_bl,nz_box)
 c average cw and rc over BL in box model if BL_box=.true.
 c      implicit double precision (a-h,o-z)
 
@@ -4871,7 +4890,7 @@ c      implicit double precision (a-h,o-z)
 
       implicit double precision (a-h,o-z)
 
-      include 'gas_Parameters.h' !additional common blocks and other definitions 
+      include 'gas_Parameters.h' !additional common blocks and other definitions
 
       common /cb53/ theta(n),thetl(n),t(n),talt(n),p(n),rho(n)
       real(kind=dp) :: theta, thetl, t, talt, p, rho
@@ -4882,10 +4901,10 @@ c      implicit double precision (a-h,o-z)
       common /kpp_dryg/ xkmtd(n,2,NSPEC),henry(n,NSPEC),xeq(n,NSPEC)
 !     common /kpp_mol/ cm(nf,nkc),xgamma(nf,j6,nkc) ! jjb unused now
 
-c note: activity coeff. are being correctly calculated with the averaged 
+c note: activity coeff. are being correctly calculated with the averaged
 c concentrations in layer n_bl
 
-c start averaging one level above "working level" 
+c start averaging one level above "working level"
 c - semi hard coded for n_bl = 2
       nstart = 2
       if (n_bl.eq.2) nstart = 3
@@ -4919,7 +4938,7 @@ c - semi hard coded for n_bl = 2
       ps    = 0.
       rhos  = 0.
       ts    = 0.
-      
+
       do k=nstart,nz_box
          am3s = am3s + am3(k)
 !         am32s = am32s + am3(k,2)
@@ -4969,7 +4988,7 @@ c calculate average photolysis rates for BL and put these values on level n_bl
       common /band_rat/ photol_j(nphrxn,n)
       double precision photol_j
 
-c start averaging one level above "working level" 
+c start averaging one level above "working level"
 c - semi hard coded for n_bl = 2
       nstart = 2
       if (n_bl.eq.2) nstart = 3
@@ -4979,7 +4998,7 @@ c - semi hard coded for n_bl = 2
          do k=nstart,nz_box
             xjsum = xjsum + photol_j(j,k)
          enddo
-         photol_j(j,n_bl) = xjsum/(nz_box-nstart+1)   
+         photol_j(j,n_bl) = xjsum/(nz_box-nstart+1)
       enddo
 
       end subroutine ave_j
@@ -4988,7 +5007,7 @@ c
 c----------------------------------------------------------------
 c
 
-      subroutine ave_aer (n_bl,nz_box) 
+      subroutine ave_aer (n_bl,nz_box)
 c average k_mt over BL in box model if BL_box=.true.
 
       USE global_params, ONLY :
@@ -4998,19 +5017,19 @@ c average k_mt over BL in box model if BL_box=.true.
 
       implicit double precision (a-h,o-z)
 
-      include 'aer_Parameters.h' !additional common blocks and other definitions          
+      include 'aer_Parameters.h' !additional common blocks and other definitions
 
       common /kpp_laer/ henry(NSPEC,nf),xkmt(nf,nkc,NSPEC),
      &     xkef(nf,nkc,NSPEC),xkeb(nf,nkc,NSPEC)
       common /kpp_2aer/ alpha(NSPEC,nf),vmean(NSPEC,nf)
 !     dimension fs(n,nka),ffsum(nka) ! jjb both not used here
 
-c start averaging one level above "working level" 
+c start averaging one level above "working level"
 c - semi hard coded for n_bl = 2
       nstart = 2
       if (n_bl.eq.2) nstart = 3
 
- 
+
       do j=1,NSPEC
          do kc=1,2
             xkmsum = 0.
@@ -5069,7 +5088,7 @@ c
 c----------------------------------------------------------------
 c
 
-      subroutine ave_tot (n_bl,nz_box) 
+      subroutine ave_tot (n_bl,nz_box)
 c average k_mt over BL in box model if BL_box=.true.
 
       USE global_params, ONLY :
@@ -5079,13 +5098,13 @@ c average k_mt over BL in box model if BL_box=.true.
 
       implicit double precision (a-h,o-z)
 
-      include 'tot_Parameters.h' !additional common blocks and other definitions          
+      include 'tot_Parameters.h' !additional common blocks and other definitions
 
       common /kpp_ltot/ henry(NSPEC,nf),xkmt(nf,nkc,NSPEC),
      &     xkef(nf,nkc,NSPEC),xkeb(nf,nkc,NSPEC)
       common /kpp_2tot/ alpha(NSPEC,nf),vmean(NSPEC,nf)
 
-c start averaging one level above "working level" 
+c start averaging one level above "working level"
 c - semi hard coded for n_bl = 2
       nstart = 2
       if (n_bl.eq.2) nstart = 3
@@ -5137,7 +5156,7 @@ c
 
       implicit double precision (a-h,o-z)
 
-      include 'aer_Parameters.h' !additional common blocks and other definitions          
+      include 'aer_Parameters.h' !additional common blocks and other definitions
 
       common /kpp_laer/ henry(NSPEC,nf),xkmt(nf,nkc,NSPEC),
      &     xkef(nf,nkc,NSPEC),xkeb(nf,nkc,NSPEC)
@@ -5155,7 +5174,7 @@ c
 c-------------------------------------------------------
 c
 
-      subroutine set_box_gas (nlevbox,n_bl) 
+      subroutine set_box_gas (nlevbox,n_bl)
 c     pick the values from the designated level: nlevbox
 
       USE global_params, ONLY :
@@ -5180,7 +5199,7 @@ c
 c-------------------------------------------------------
 c
 
-      subroutine set_box_lev_a (nlevbox,n_bl) 
+      subroutine set_box_lev_a (nlevbox,n_bl)
 c     pick the values from the designated level: nlevbox
 
       USE global_params, ONLY :
@@ -5252,7 +5271,7 @@ c     pick the values from the designated level: nlevbox
 c SR cw_rc is still being called, therefore also init f
       do ia=1,nka
          do jt=1,nkt
-            ff(jt,ia,n_bl) = ff(jt,ia,nlevbox) 
+            ff(jt,ia,n_bl) = ff(jt,ia,nlevbox)
          enddo
       enddo
 
@@ -5263,8 +5282,8 @@ c-------------------------------------------------------
 c
 
 
-      subroutine set_box_lev_t (nlevbox,n_bl) 
-c     pick the values from the designated level: nlevbox    
+      subroutine set_box_lev_t (nlevbox,n_bl)
+c     pick the values from the designated level: nlevbox
 
       USE global_params, ONLY :
 ! Imported Parameters:
@@ -5279,7 +5298,7 @@ c     pick the values from the designated level: nlevbox
 
       implicit double precision (a-h,o-z)
 
-      include 'tot_Parameters.h' !additional common blocks and other definitions          
+      include 'tot_Parameters.h' !additional common blocks and other definitions
 
       common /cb11/ totrad (mb,n)
       double precision totrad
@@ -5355,7 +5374,7 @@ c     test output
 
       implicit double precision (a-h,o-z)
 
-      include 'aer_Parameters.h' !additional common blocks and other definitions          
+      include 'aer_Parameters.h' !additional common blocks and other definitions
 
       common /cb11/ totrad (mb,n)
       double precision totrad
@@ -5420,9 +5439,9 @@ c     test output
 
       print *,'parameters'
 !     print *,am3(k,1),am3(k,2),p(k) ! jjb am3 CO removed
-      print *,am3(k),p(k)    
+      print *,am3(k),p(k)
 !     print *,cm3(k,1),cm3(k,2),rho(k) ! jjb cm3 CO removed
-      print *,cm3(k),rho(k)  
+      print *,cm3(k),rho(k)
       print *,t(k), totrad(1,k)
 
       print *,'alpha,henry,vmean'
@@ -5547,7 +5566,7 @@ c$$$            endif
 c$$$c fast version without logarithmic integration
 c$$$            x1=0.
 c$$$            xk1=0.
-c$$$c --- OH + Cl- --> 0.5 Cl2 + OH- --- 
+c$$$c --- OH + Cl- --> 0.5 Cl2 + OH- ---
 c$$$c "best guess": use alpha from Knipping and Dabdub and gas phase limitation:
 c$$$c alpha = 0.02 * gamma_s * [Cl-], where [Cl-] is in mol/l, gamma_s=2
 c$$$c C(ind_Clmlx) / LWC *1.d-3:  in mol/m3_air * m3_air/m3_aq * m3_aq/l_aq
@@ -5595,11 +5614,11 @@ c$$$!               xkmt_surf(k,kc)=4.*3.1415927/(3.*cw(kc,k))*xk1 ![1/s]
 c$$$               xkmt_surf(k,kc)=4.*pi/(3.*cw(kc,k))*xk1 ![1/s]
 c$$$            end if
 c$$$
-c$$$c kmt is supposed to be a first-order rate coefficient but in KPP kmt will 
+c$$$c kmt is supposed to be a first-order rate coefficient but in KPP kmt will
 c$$$c be multiplied by [Cl-]/[Br-], so divide by [X-] here:
 c$$$
-c$$$            if (sion1(14,kc,k).gt.0.) 
-c$$$     &           xkmt_OHClm(k,kc)=xkmt_surf(k,kc)/sion1(14,kc,k)  
+c$$$            if (sion1(14,kc,k).gt.0.)
+c$$$     &           xkmt_OHClm(k,kc)=xkmt_surf(k,kc)/sion1(14,kc,k)
 c$$$
 c$$$c            print *,'SR gamma_surf'
 c$$$c            print *,lday,lst,lmin
@@ -5611,7 +5630,7 @@ c$$$c     &           sion1(24,kc,k)
 c$$$
 c$$$ 1001       continue
 c$$$         enddo                  ! kc
-c$$$         
+c$$$
 c$$$ 1000 continue                  !k
 c$$$
 c$$$      end subroutine gamma_surf
@@ -5624,18 +5643,23 @@ c
 
 c functions for KPP
 
-c third body reaction rate constants are formulated as pseudo 
+c third body reaction rate constants are formulated as pseudo
 c second order: cm^3/s, so [aircc]=cm^3/s has to be used
 
       double precision function farr (a,b)
 c Arrhenius relation
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a
-      integer b
+      real (kind=dp) :: a
+      integer :: b
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       farr=a*exp(b/te)
       end function farr
@@ -5644,13 +5668,18 @@ c----------------------------------------------------------------
 
       double precision function farr_sp (a,b,c,d)
 c Arrhenius relation (with complex temperature dependence)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a,c
-      integer b,d
+      real (kind=dp) :: a,c
+      integer :: b,d
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       farr_sp=a*((te/b)**c)*exp(d/te)
       end function farr_sp
@@ -5659,12 +5688,17 @@ c----------------------------------------------------------------
 
       double precision function ATK_3 (a1,a2,b1,b2,fc)
 c calculate third body reactions according to Atkinson '92
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,a2,b1,b2,fc,x2
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,fc,x2
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*aircc*(te/300.)**a2
       b0=b1*(te/300.)**b2
@@ -5678,10 +5712,17 @@ c----------------------------------------------------------------
 
       double precision function ATK_3a (a1,a2,b1,b2,tfc)
 c calculate third body reactions according to Atkinson '92
-      double precision a0,b0,a1,a2,b1,b2,tfc,x2
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+      implicit none
+
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,tfc,x2
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*aircc*(te/300.)**a2
       b0=b1*(te/300.)**b2
@@ -5694,12 +5735,17 @@ c----------------------------------------------------------------
 
       double precision function ATK_3c (a1,b1,fc)
 c calculate third body reactions according to Atkinson '92
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,b1,fc,x2
+      real (kind=dp) :: a0,b0,a1,b1,fc,x2
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*exp(-10000./te)*aircc
       b0=b1*exp(-10900./te)
@@ -5713,12 +5759,17 @@ c----------------------------------------------------------------
 
       double precision function ATK_3d (a1,b1,fc)
 c calculate third body reactions according to IUPAC 2004
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,b1,fc,x2
+      real (kind=dp) :: a0,b0,a1,b1,fc,x2
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*exp(-8000./te)*aircc
       b0=b1*exp(-8820./te)
@@ -5734,12 +5785,17 @@ c calculate third body reactions according to Atkinson '92 (used for OH + OIO)
 c  NOT USED: Plane et al., 2006 reported a pressure dependent rate coefficient
 c  from a theoretical study, however they suggested an Arrhenius relationship
 c  for use in atmospheric modelling
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,a2,b1,b2,fc,x2
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,fc,x2
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*aircc*(te/300.)**a2
       b0=b1*(te/300.)**b2*exp(46./te)
@@ -5753,12 +5809,17 @@ c----------------------------------------------------------------
 
       double precision function ATK_3f (a1,a2,b1,b2,fc)
 c calculate third body reactions according to Atkinson '92 (used for OCLO + O3P)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,a2,b1,b2,fc,x2
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,fc,x2
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*aircc*(te/298.)**a2
       b0=b1*(te/298.)**b2
@@ -5772,13 +5833,18 @@ c----------------------------------------------------------------
 
       double precision function sHNO3 (a1,b1,a2,b2,a3,b3)
 c calculate special rate function for OH + HNO3 (JPL 2003)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,a1,a2,a3,func,tte
-      integer b0,b1,b2,b3
+      real (kind=dp) :: a0,a1,a2,a3,func,tte
+      integer :: b0,b1,b2,b3
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       func(a0,b0)=a0*exp(b0*tte)
       tte=1./te
@@ -5791,12 +5857,17 @@ c----------------------------------------------------------------
       double precision function fbck (a1,a2,b1,b2,fc,ak,bk)
 c calculate thermal decomposition rate from forward and
 c equilibrium rate
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,a2,b1,b2,fc,x1,x2,ak,bk
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,fc,x1,x2,ak,bk
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*aircc*(te/300.d0)**a2
       b0=b1*(te/300.d0)**b2
@@ -5812,12 +5883,17 @@ c----------------------------------------------------------------
       double precision function fbckJ (a1,a2,b1,b2,ak,bk)
 c calculate thermal decomposition rate from forward and
 c equilibrium rate
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,a2,b1,b2,x1,x2,ak,bk
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,x1,x2,ak,bk
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       a0=a1*aircc*(te/300.d0)**a2
       b0=b1*(te/300.d0)**b2
@@ -5833,12 +5909,17 @@ c----------------------------------------------------------------
       double precision function fbck2 (a1,a2,b1,b2,fc,ck)
 c calculate thermal decomposition rate from forward and
 c equilibrium rate (used for BrNO3 decomposition)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,b0,a1,a2,b1,b2,fc,x1,x2,ak,bk,ck
+      real (kind=dp) :: a0,b0,a1,a2,b1,b2,fc,x1,x2,ak,bk,ck
 
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
 c parameters to calculate K_eq in atm-1 (Orlando and Tyndall, 1996)
       ak=5.44d-9
@@ -5858,11 +5939,16 @@ c----------------------------------------------------------------
 
       double precision function sp_17_old (a1)
 c calculate special rate function for rxn 17 (OH + CO)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a1
+      real (kind=dp) :: a1
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       sp_17_old=a1*(1+0.6*pk/101325.) !(pressure in atm)
       end function sp_17_old
@@ -5871,11 +5957,16 @@ c----------------------------------------------------------------
 
       double precision function sp_17 (a,b)
 c calculate special rate function for rxn 17 (OH + CO)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a,b
+      real (kind=dp) :: a,b
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       sp_17=a*(1.d0+aircc/b) ! simpler IUPAC parametrization
 c$$$      sp_17=a1*(1+0.6*pk/101325.) !(pressure in atm)
@@ -5885,12 +5976,17 @@ c----------------------------------------------------------------
 
       double precision function sp_23 (a1,b1,a2,b2,a3,b3)
 c calculate special rate function for rxn 23 (HO2+HO2 - including H2O correction)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0,a1,a2,a3,func,tte
-      integer b0,b1,b2,b3
+      real (kind=dp) :: a0,a1,a2,a3,func,tte
+      integer :: b0,b1,b2,b3
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       func(a0,b0)=a0*exp(b0*tte)
       tte=1./te
@@ -5902,12 +5998,17 @@ c----------------------------------------------------------------
 
       double precision function sp_29 (a1,b1,a2,b2,c)
 c calculate special rate function for rxn 29
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a1,b1,a2,b2,c,fun1,fun2,fun3,num,den,z,
+      real (kind=dp) :: a1,b1,a2,b2,c,fun1,fun2,fun3,num,den,z,
      & a0,b0,c0,d0
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       fun1(a0,b0,c0)=a0*(b0**c0)
       fun2(a0,b0)=1./(1.+(dlog10(a0/b0))*(dlog10(a0/b0)))
@@ -5916,18 +6017,23 @@ c calculate special rate function for rxn 29
       num=aircc*fun1(a1,te,b1)
       den=    fun1(a2,te,b2)
       z=fun2(num,den)
-      sp_29=fun3(num,den,c,z)    
+      sp_29=fun3(num,den,c,z)
       end function sp_29
 
 c----------------------------------------------------------------
 
       double precision function fcn (x1)
 c rate constant for thermal decomposition of ClNO3 (#2730)
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision x1,x2,xmg
+      real (kind=dp) :: x1,x2,xmg
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       x2=8.314*te
       xmg=pk/x2
@@ -5938,12 +6044,17 @@ c----------------------------------------------------------------
 
       double precision function farr2 (a0,b0)
 c Arrhenius function but with b0 as the value for T=298K
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
       implicit none
 
-      double precision a0
-      integer b0
+      real (kind=dp) :: a0
+      integer :: b0
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 c 1/298.=3.3557d-3
       farr2=a0*exp(dble(b0)*(1.d0/te-3.3557d-3))
       end function farr2
@@ -5951,12 +6062,17 @@ c 1/298.=3.3557d-3
 c----------------------------------------------------------------
 
       double precision function fhet_t (a0,b0,c0)
-c heterogeneous rate function 
+c heterogeneous rate function
 c ClFCT     = 5.0D2                ; factor for H02/H01, i.e Cl-/H2O
 c BrFCT     = 3.0D5                ; factor for H03/H01, i.e Br-/H2O
 c a0=1..4  liquid size class
 c b0=1..3  branch of het reaction: H2O, Cl-, Br-
 c c0=1..3  gas phase reactant:     N2O5, ClNO3, BrNO3
+
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
 
       implicit none
 
@@ -5964,8 +6080,8 @@ c c0=1..3  gas phase reactant:     N2O5, ClNO3, BrNO3
       INCLUDE 'tot_Global.h'
       integer, intent(in) :: a0,b0,c0
 
-      double precision :: h2oa, hetT
-      double precision :: xbr, xtr
+      real (kind=dp) :: h2oa, hetT
+      real (kind=dp) :: xbr, xtr
 
       if (a0.eq.1) then
          h2oa=FIX(indf_H2Ol1)
@@ -6026,12 +6142,17 @@ c----------------------------------------------------------------
       double precision function fliq_60 (a1,b1,c,d)
 c calculate special rate function for rxn 60
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a1,c,d
-      integer b1
+      real (kind=dp) :: a1,c,d
+      integer :: b1
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
       if (d.gt.0.d0) then
 c         fliq_60=farr2(a1,b1)*c/(c+0.1/d)
@@ -6045,11 +6166,16 @@ c----------------------------------------------------------------
 
       double precision function dmin2 (a)
 c confine rate constant to upper limit (diffusion control)
-c a=k; dclim=upper limit due to diffusion-control 
+c a=k; dclim=upper limit due to diffusion-control
+
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
 
       implicit none
 
-      double precision a,dclim
+      real (kind=dp) :: a,dclim
 
       dclim = 1.d10
 
@@ -6065,9 +6191,14 @@ c a=k; dclim=upper limit due to diffusion-control
 c factor 2.d0 is to account for larger upper limit for
 c    2nd order reactions between differtly-charged ions
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a,dclim
+      real (kind=dp) :: a,dclim
 
       dclim = 1.d10
 
@@ -6078,14 +6209,19 @@ c    2nd order reactions between differtly-charged ions
 c----------------------------------------------------------------
 
       double precision function flsc (a,b,c,d)
-c calculate special rate function  
+c calculate special rate function
 c after #s_364, Schmitz (1999), eq.(4) / #s_650, Schmitz (2000)
 c: dio3/dt = k1*[IO3-][H+]^2[I-]^2 + k2*[IO3-][H+]^2[I-]
 c a=k1, b=H+, c=I-, d=cvvz
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a,b,c,d
+      real (kind=dp) :: a,b,c,d
 
       if (d.gt.0.d0) then
          flsc=( a*b**2*d**4 + 1.2d3*b**2/c*d**3 )
@@ -6097,13 +6233,18 @@ c a=k1, b=H+, c=I-, d=cvvz
 c----------------------------------------------------------------
 
       double precision function flsc4 (a,b,c)
-c calculate special rate function 
+c calculate special rate function
 c after #s_650, Schmitz (2000)
 c a=k4, b=H+, c=cvvz
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a,b,c
+      real (kind=dp) :: a,b,c
 
       if (c.gt.0.d0) then
          flsc4=( a*b*c**3 )
@@ -6115,13 +6256,18 @@ c a=k4, b=H+, c=cvvz
 c----------------------------------------------------------------
 
       double precision function flsc5 (a,b,c)
-c calculate special rate function 
+c calculate special rate function
 c after #s_650, Schmitz (2000)
 c a=k5, b=H+, c=cvvz
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a,b,c
+      real (kind=dp) :: a,b,c
 
       if (c.gt.0.d0) then
         flsc5=( a*b**2*c**4 )
@@ -6194,9 +6340,14 @@ c----------------------------------------------------------------
 
       double precision function uplim (a,b,c,d)
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a,b,c,d,dclim
+      real (kind=dp) :: a,b,c,d,dclim
 c dclim = upper limit for diffusion-controlled reactions
 c a=k-; b=k+; alpha=b/dclim; c=H+; d=cvvz;
 
@@ -6217,12 +6368,17 @@ c Arrhenius function but with b0 as the value for T=298K
 c dclim = upper limit for diffusion-controlled reactions
 c c=k+; alpha=c/dclim; d=[H+]; e=cvvz
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a0,c,d,e,dclim
-      integer b0
+      real (kind=dp) :: a0,c,d,e,dclim
+      integer :: b0
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 c 1/298.=3.3557d-3
 
       dclim = 1.d10
@@ -6237,9 +6393,14 @@ c----------------------------------------------------------------
 
       double precision function uplip (a,b,c)
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a,b,c,dclim
+      real (kind=dp) :: a,b,c,dclim
 c dclim = upper limit for diffusion-controlled 3rd order reactions
 c with H+ as reactant
 c a=k+; b=[H+]; c=cvvz; alpha=a/dclim
@@ -6261,12 +6422,17 @@ c Arrhenius function but with b0 as the value for T=298K
 c dclim = upper limit for diffusion-controlled reactions
 c c=H+; d=cvvz; alpha=f(a0,b0)/dclim
 
+      USE precision, ONLY :
+! Imported Parameters:
+     &     dp
+
+
       implicit none
 
-      double precision a0,c,d,dclim
-      integer b0
+      real (kind=dp) :: a0,c,d,dclim
+      integer :: b0
       common /cb_1/ aircc,te,h2oppm,pk
-      double precision aircc,te,h2oppm,pk
+      real (kind=dp) :: aircc,te,h2oppm,pk
 
 c 1/298.=3.3557d-3
 
@@ -6351,7 +6517,7 @@ c c0=1..3  gas phase reactant:     N2O5, ClNO3, BrNO3
       else
          fhet_da=0.
       endif
-      if ((c0.eq.2.or.c0.eq.3.or.b0.eq.2.or.b0.eq.3).and.xhal.eq.0.) 
+      if ((c0.eq.2.or.c0.eq.3.or.b0.eq.2.or.b0.eq.3).and.xhal.eq.0.)
      &     fhet_da=0.
       if (xliq.eq.0.) fhet_da=0.
 !      print*,xliq,a0,c0,fhet_da
@@ -6360,7 +6526,7 @@ c c0=1..3  gas phase reactant:     N2O5, ClNO3, BrNO3
 c----------------------------------------------------------
 
       double precision function fhet_dt (xliq,xhet,a0,b0,c0)
-c heterogeneous rate function 
+c heterogeneous rate function
 c ClFCT     = 5.0D2                ; factor for H02/H01, i.e Cl-/H2O
 c BrFCT     = 3.0D5                ; factor for H03/H01, i.e Br-/H2O
 c a0=1..2  liquid size class
@@ -6428,7 +6594,7 @@ c c0=1..3  gas phase reactant:     N2O5, ClNO3, BrNO3
       else
          fhet_dt=0.
       endif
-      if ((c0.eq.2.or.c0.eq.3.or.b0.eq.2.or.b0.eq.3).and.xhal.eq.0.) 
+      if ((c0.eq.2.or.c0.eq.3.or.b0.eq.2.or.b0.eq.3).and.xhal.eq.0.)
      &     fhet_dt=0.
       if (xliq.eq.0.) fhet_dt=0.
 
@@ -6437,7 +6603,7 @@ c c0=1..3  gas phase reactant:     N2O5, ClNO3, BrNO3
 c----------------------------------------------------------
 
       double precision function fdhetg (na,nb)
-c heterogeneous rate function 
+c heterogeneous rate function
 c a0=1..2  liquid size class
 
 ! na is bin number
@@ -6456,16 +6622,16 @@ c net mass transfer coefficient including Henry's law equilibrium for HNO3
 
       if (nb.eq.1) then
 c not limited by Henry's law:
-c         xkt=yxkmtd(na,ind_HNO3) * ycwd(na) 
+c         xkt=yxkmtd(na,ind_HNO3) * ycwd(na)
 
 c limited by Henry's law:
 c see Diss RvG (3.10): dcg/dt = ... + kmt(LWC*Cg - Ca/H), this term is implemented here
 c note that Cg is multiplied to rate in KPP, therefore the heterogeneous reaction rate is:
 c     kmt(LWC - Ca/(Cg*H)) = x1 + x2
-c     in x2 the "aqueous" concentration of HNO3 on the dry aerosol is calculated via 
+c     in x2 the "aqueous" concentration of HNO3 on the dry aerosol is calculated via
 c     Henry's law and a HARDCODED particle pH = 2
-     
-         x1 = yxkmtd(na,ind_HNO3) * ycwd(na) 
+
+         x1 = yxkmtd(na,ind_HNO3) * ycwd(na)
 c index out of bounds in C(ind_NO3mlz) as this is not known in gas_Parameters.h
 c         if (na.eq.1) caq=((C(ind_HNO3l1)+C(ind_NO3ml1))*1.d-2)/
 c     &        (yxeq(ind_HNO3) + 1.d-2)
@@ -6479,22 +6645,22 @@ c this is all VERY rough and should be replaced!!
          if (na.eq.2) caq=((C(ind_HNO3l2)*1.5d3)*1.d-2)/
      &        (yxeq(ind_HNO3) + 1.d-2)
          x2 = 0.d0
-          if (C(ind_HNO3).ne.0.d0.and.yhenry(ind_HNO3).ne.0.d0) 
+          if (C(ind_HNO3).ne.0.d0.and.yhenry(ind_HNO3).ne.0.d0)
      &        x2=-yxkmtd(na,ind_HNO3)/(C(ind_HNO3)*yhenry(ind_HNO3))*caq
          xkt = max(0.d0,(x1 + x2))
       endif
 c kmt in (m^3_air/(m^3_aq*s)) therefore multiplication with LWC (m^3_aq/m^3_air)
 c to get k in 1/s:
-      if (nb.eq.2) xkt=yxkmtd(na,ind_N2O5) * ycwd(na) 
-      if (nb.eq.3) xkt=yxkmtd(na,ind_NH3) * ycwd(na) 
-      if (nb.eq.4) xkt=yxkmtd(na,ind_H2SO4) * ycwd(na) 
+      if (nb.eq.2) xkt=yxkmtd(na,ind_N2O5) * ycwd(na)
+      if (nb.eq.3) xkt=yxkmtd(na,ind_NH3) * ycwd(na)
+      if (nb.eq.4) xkt=yxkmtd(na,ind_H2SO4) * ycwd(na)
 
 
       fdhetg=xkt
 
 c      print *,k,na,nb
 c      print *,fdhetg,xkt,ycwd(na)
-c      if (nb.eq.1) write (440, 1001) k,na,nb,fdhetg,yxkmtd(na,ind_HNO3) 
+c      if (nb.eq.1) write (440, 1001) k,na,nb,fdhetg,yxkmtd(na,ind_HNO3)
 c     &     * ycwd(na)
 ! 1001 format(3i4, 6d16.8)
 
@@ -6503,7 +6669,7 @@ c     &     * ycwd(na)
 c----------------------------------------------------------------
 
       double precision function fdheta (na,nb)
-c heterogeneous rate function 
+c heterogeneous rate function
 c a0=1..2  liquid size class
 
       implicit double precision (a-h,o-z)
@@ -6514,7 +6680,7 @@ c a0=1..2  liquid size class
 c see explanation in FCN fdhetg
 
       if (nb.eq.1) then
-         x1 = yxkmtd(na,ind_HNO3) * ycwd(na) 
+         x1 = yxkmtd(na,ind_HNO3) * ycwd(na)
          caq = 0.d0
          if ((yxeq(ind_HNO3)+1.d-2).ne.0.d0) then
             if (na.eq.1) caq=((C(ind_HNO3l1)+C(ind_NO3ml1))*1.d-2)/
@@ -6523,15 +6689,15 @@ c see explanation in FCN fdhetg
      &           (yxeq(ind_HNO3) + 1.d-2)
          endif
          x2 = 0.d0
-          if (C(ind_HNO3).ne.0.d0.and.yhenry(ind_HNO3).ne.0.d0) 
+          if (C(ind_HNO3).ne.0.d0.and.yhenry(ind_HNO3).ne.0.d0)
      &        x2=-yxkmtd(na,ind_HNO3)/(C(ind_HNO3)*yhenry(ind_HNO3))*caq
          xkt = max(0.d0,(x1 + x2))
       endif
-      if (nb.eq.2) xkt=yxkmtd(na,ind_N2O5) * ycwd(na) 
-      if (nb.eq.3) xkt=yxkmtd(na,ind_NH3) * ycwd(na) 
-      if (nb.eq.4) xkt=yxkmtd(na,ind_H2SO4) * ycwd(na) 
+      if (nb.eq.2) xkt=yxkmtd(na,ind_N2O5) * ycwd(na)
+      if (nb.eq.3) xkt=yxkmtd(na,ind_NH3) * ycwd(na)
+      if (nb.eq.4) xkt=yxkmtd(na,ind_H2SO4) * ycwd(na)
 
-      fdheta=xkt 
+      fdheta=xkt
 
       end function fdheta
 
@@ -6539,7 +6705,7 @@ c-----------------------------------------------------------------------------
 
 
       double precision function fdhett (na,nb)
-c heterogeneous rate function 
+c heterogeneous rate function
 c a0=1..2  liquid size class
 
       implicit double precision (a-h,o-z)
@@ -6550,7 +6716,7 @@ c a0=1..2  liquid size class
 c see explanation in FCN fdhetg
 
       if (nb.eq.1) then
-         x1 = yxkmtd(na,ind_HNO3) * ycwd(na) 
+         x1 = yxkmtd(na,ind_HNO3) * ycwd(na)
          caq = 0.d0
          if ((yxeq(ind_HNO3)+1.d-2).ne.0.d0) then
             if (na.eq.1) caq=((C(ind_HNO3l1)+C(ind_NO3ml1))*1.d-2)/
@@ -6559,15 +6725,15 @@ c see explanation in FCN fdhetg
      &           (yxeq(ind_HNO3) + 1.d-2)
          endif
          x2 = 0.d0
-          if (C(ind_HNO3).ne.0.d0.and.yhenry(ind_HNO3).ne.0.d0) 
+          if (C(ind_HNO3).ne.0.d0.and.yhenry(ind_HNO3).ne.0.d0)
      &        x2=-yxkmtd(na,ind_HNO3)/(C(ind_HNO3)*yhenry(ind_HNO3))*caq
          xkt = max(0.d0,(x1 + x2))
       endif
-      if (nb.eq.2) xkt=yxkmtd(na,ind_N2O5) * ycwd(na) 
-      if (nb.eq.3) xkt=yxkmtd(na,ind_NH3) * ycwd(na) 
-      if (nb.eq.4) xkt=yxkmtd(na,ind_H2SO4) * ycwd(na) 
+      if (nb.eq.2) xkt=yxkmtd(na,ind_N2O5) * ycwd(na)
+      if (nb.eq.3) xkt=yxkmtd(na,ind_NH3) * ycwd(na)
+      if (nb.eq.4) xkt=yxkmtd(na,ind_H2SO4) * ycwd(na)
 
-      fdhett=xkt 
+      fdhett=xkt
 
       end function fdhett
 
@@ -6595,7 +6761,7 @@ cc rate coefficient for recmonbination Hg+Br --> HgBr (Donohoue et al., 2006, #4
 c      double precision aircc,te,h2oppm,pk,x1,x2
 c      common /cb_1/ aircc,te,h2oppm,pk
 c
-cc reaction is 3rd order, multiply with conversion factors here (instead of in 
+cc reaction is 3rd order, multiply with conversion factors here (instead of in
 cc master_gas.eqn) in order to have an argument for the function
 cc note that the fit that they give does not exactly reproduce the measured values in their Tables 1 and 2)
 c      xkHgBr = 1.46d-32 * (te/298.)**(-1.86) * x1 * x1
@@ -6608,7 +6774,7 @@ cc rate coefficient for recombination HgBr+Br --> HgBr2 (Goodsite et al., 2004, 
 c      double precision aircc,te,h2oppm,pk,x1
 c      common /cb_1/ aircc,te,h2oppm,pk
 c
-cc reaction is 2nd order, multiply with conversion factor here (instead of in 
+cc reaction is 2nd order, multiply with conversion factor here (instead of in
 cc master_gas.eqn) in order to have an argument for the function
 c      xkHgBrBr = 2.5d-10*(te/298.d0)**(-.57d0) * x1
 c      end function xkHgBrBr
@@ -6621,7 +6787,7 @@ cc (#3244) but scaled with ratio of Donohoue and Goodsite as
 cc suggested in Seigneur and Lohmann, 2008 (#4136)
 c      double precision aircc,te,h2oppm,pk,x1,x2,xkHgBr
 c      common /cb_1/ aircc,te,h2oppm,pk
-c      
+c
 c      if (te.eq.0.d0) then
 c         xkGood = 0.d0
 c      else

--- a/src/out_netCDF.f
+++ b/src/out_netCDF.f
@@ -46,7 +46,7 @@ c supplemented by Susanne Marquart, Sep 2004
 !
 ! ================================================================
 
-c open netCDF-files      
+c open netCDF-files
       true=.true. ! to be able to compare hal vs. nohal
       call open_met (n_bln)                         ! thermodynamics
       if (mic)   call open_mic                      ! microphysics
@@ -58,7 +58,7 @@ c      if (chem)  call open_chem_aq(n_bln,halo,iod) ! aqueous phase
       if (chem)  call open_jrate (n_bln)            ! photolysis rates
       if (chem)  call open_rxn                      ! reaction rates
       if (nuc)   call open_nuc                      ! nucleation
-      call open_grid ! writes information on grid that is not f(t) 
+      call open_grid ! writes information on grid that is not f(t)
 c      call write_grid ! writes information on grid that is not f(t)
 c      this call is now in main program AFTER call to SR grid
 
@@ -77,7 +77,7 @@ c
 
       logical :: true
 
-c write netCDF-files      
+c write netCDF-files
       true=.true.
       call write_met (n_bln)                          ! thermodynamics
       if (mic.and..not.box) call write_mic             ! microphysics
@@ -99,7 +99,7 @@ c
       implicit none
 
       logical :: chem,mic,nuc
-c close netCDF-files      
+c close netCDF-files
       call close_met
       if (mic)   call close_mic
       if (chem)  call close_chem_gas
@@ -357,7 +357,7 @@ c turbulence parameters
       if (k.ne.nf_noerr) call ehandle(k,fname)
       k=nf_put_att_text(idfile,idvar(24),'units',6, 'm2 s-1')
       if (k.ne.nf_noerr) call ehandle(k,fname)
-      
+
       k=nf_def_var(idfile,'tke',nf_float,4,jddim1,idvar(25))
       if (k.ne.nf_noerr) call ehandle(k,fname)
       k=nf_put_att_text(idfile,idvar(25),'long_name',24,
@@ -388,7 +388,7 @@ c flux divergences
       if (k.ne.nf_noerr) call ehandle(k,fname)
       k=nf_put_att_text(idfile,idvar(28),'units',6,'m s-2')
       if (k.ne.nf_noerr) call ehandle(k,fname)
-      
+
       k=nf_def_var(idfile,'fd_v',nf_float,4,jddim1,idvar(29))
       if (k.ne.nf_noerr) call ehandle(k,fname)
       k=nf_put_att_text(idfile,idvar(29),'long_name',15,
@@ -481,13 +481,13 @@ c end define mode
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end
-      
+
 c
 c----------------------------------------------------------------
 c
 
 
-      subroutine open_grid 
+      subroutine open_grid
 c initialize plot file for grid output
 c ferret complains about variable ordering but the way I set it up "i", "j", "k" refer to the same parameters (nka, nkt, n) in grid and f etc
 
@@ -633,8 +633,8 @@ c end define mode
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end
-      
-  
+
+
 c
 c----------------------------------------------------------------
 c
@@ -768,8 +768,8 @@ c end define mode
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end
-      
-      
+
+
 c
 c----------------------------------------------------------------
 c
@@ -864,7 +864,7 @@ c long lived gas phase species
       jddim1(3)=id_n
       jddim1(4)=idgas_rec
 
-c offset due to time variables      
+c offset due to time variables
       i0 = j0
 
       do j = 1,j1
@@ -906,7 +906,7 @@ c end define mode
 c
 c----------------------------------------------------------------
 c
-      
+
       subroutine open_chem_aq(n_bln,halo,iod,nuc)
 c open netCDF file for aqueous phase chemistry output
 
@@ -985,7 +985,7 @@ c aqueous phase species
       jddim1(2)=id_y
       jddim1(3)=id_n
       jddim1(4)=idaq_rec
-c offset due to time variables      
+c offset due to time variables
       i0 = 3
 
       k=nf_def_var(idaqfile,'NO',nf_float,4,jddim1,idvar_aq(i0+1))
@@ -1331,7 +1331,7 @@ c      if (k.ne.nf_noerr) call ehandle(k,fname)
          k=nf_put_att_text(idaqfile,idvar_aq(i0+38),'units',14,
      &        'mol m-3 (air) ')
          if (k.ne.nf_noerr) call ehandle(k,fname)
-         
+
 c         k=nf_def_var(idaqfile,'ClNO2',nf_float,4,jddim1,idvar_aq(i0+39))
 c         if (k.ne.nf_noerr) call ehandle(k,fname)
 c         k=nf_put_att_text(idaqfile,idvar_aq(i0+39),'long_name',14,
@@ -1340,7 +1340,7 @@ c         if (k.ne.nf_noerr) call ehandle(k,fname)
 c         k=nf_put_att_text(idaqfile,idvar_aq(i0+39),'units',14,
 c     &        'mol m-3 (air) ')
 c         if (k.ne.nf_noerr) call ehandle(k,fname)
-c         
+c
 c         k=nf_def_var(idaqfile,'ClNO3',nf_float,4,jddim1,idvar_aq(i0+40))
 c         if (k.ne.nf_noerr) call ehandle(k,fname)
 c         k=nf_put_att_text(idaqfile,idvar_aq(i0+40),'long_name',20,
@@ -1349,7 +1349,7 @@ c         if (k.ne.nf_noerr) call ehandle(k,fname)
 c         k=nf_put_att_text(idaqfile,idvar_aq(i0+40),'units',14,
 c     &        'mol m-3 (air) ')
 c         if (k.ne.nf_noerr) call ehandle(k,fname)
-         
+
          k=nf_def_var(idaqfile,'Cl2',nf_float,4,jddim1,idvar_aq(i0+41))
          if (k.ne.nf_noerr) call ehandle(k,fname)
          k=nf_put_att_text(idaqfile,idvar_aq(i0+41),'long_name',19,
@@ -1385,7 +1385,7 @@ c         if (k.ne.nf_noerr) call ehandle(k,fname)
 c         k=nf_put_att_text(idaqfile,idvar_aq(i0+44),'units',14,
 c     &        'mol m-3 (air) ')
 c         if (k.ne.nf_noerr) call ehandle(k,fname)
-c         
+c
 c         k=nf_def_var(idaqfile,'BrNO3',nf_float,4,jddim1,idvar_aq(i0+45))
 c         if (k.ne.nf_noerr) call ehandle(k,fname)
 c         k=nf_put_att_text(idaqfile,idvar_aq(i0+45),'long_name',20,
@@ -1502,7 +1502,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
 c            k=nf_put_att_text(idaqfile,idvar_aq(i0+48),'units',14,
 c     &           'mol m-3 (air) ')
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
-            
+
             k=nf_def_var(idaqfile,'HOI',nf_float,4,jddim1,
      &       idvar_aq(i0+49))
             if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1512,7 +1512,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
             k=nf_put_att_text(idaqfile,idvar_aq(i0+49),'units',14,
      &           'mol m-3 (air) ')
             if (k.ne.nf_noerr) call ehandle(k,fname)
-            
+
 c            k=nf_def_var(idaqfile,'I2O2',nf_float,4,jddim1,
 c     &        idvar_aq(i0+50))
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1522,7 +1522,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
 c            k=nf_put_att_text(idaqfile,idvar_aq(i0+50),'units',14,
 c     &           'mol m-3 (air) ')
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
-c            
+c
 c            k=nf_def_var(idaqfile,'INO2',nf_float,4,jddim1,
 c     &        idvar_aq(i0+51))
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1532,7 +1532,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
 c            k=nf_put_att_text(idaqfile,idvar_aq(i0+51),'units',14,
 c     &           'mol m-3 (air) ')
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
-c            
+c
 c            k=nf_def_var(idaqfile,'INO3',nf_float,4,jddim1,
 c     &        idvar_aq(i0+52))
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1542,7 +1542,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
 c            k=nf_put_att_text(idaqfile,idvar_aq(i0+52),'units',14,
 c     &           'mol m-3 (air) ')
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
-            
+
             k=nf_def_var(idaqfile,'I2',nf_float,4,jddim1,
      &       idvar_aq(i0+53))
             if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1552,7 +1552,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
             k=nf_put_att_text(idaqfile,idvar_aq(i0+53),'units',14,
      &           'mol m-3 (air) ')
             if (k.ne.nf_noerr) call ehandle(k,fname)
-            
+
             k=nf_def_var(idaqfile,'ICl',nf_float,4,jddim1,
      &        idvar_aq(i0+54))
             if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1562,7 +1562,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
             k=nf_put_att_text(idaqfile,idvar_aq(i0+54),'units',14,
      &           'mol m-3 (air) ')
             if (k.ne.nf_noerr) call ehandle(k,fname)
-            
+
             k=nf_def_var(idaqfile,'IBr',nf_float,4,jddim1,
      &           idvar_aq(i0+55))
             if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -1602,7 +1602,7 @@ c            if (k.ne.nf_noerr) call ehandle(k,fname)
 c            k=nf_put_att_text(idaqfile,idvar_aq(i0+58),'units',14,
 c     &           'mol m-3 (air) ')
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
-c            
+c
 c            k=nf_def_var(idaqfile,'C3H7I',nf_float,4,jddim1,
 c     &         idvar_aq(i0+59))
 c            if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -2096,7 +2096,7 @@ c rvg: it's NOT possible to replace "p" and "m" with"+" and "-"
 
 c offset due to time variables and non-ionic species:
       i2=j1+j3+i0
-     
+
 
       k=nf_def_var(idaqfile,'Hp',nf_float,4,jddim1,idvar_aq(i2+1))
       if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -2562,7 +2562,7 @@ c      k=nf_put_att_text(idaqfile,idvar_aq(i2+50),'units',14,
 c     & 'mol m-3 (air) ')
 c      if (k.ne.nf_noerr) call ehandle(k,fname)
 
-c LWC per aqueous bin 
+c LWC per aqueous bin
       k=nf_def_var(idaqfile,'cw',nf_float,4,jddim1,idvar_aq(i2+41))
       if (k.ne.nf_noerr) call ehandle(k,fname)
       k=nf_put_att_text(idaqfile,idvar_aq(i2+41),'long_name',20,
@@ -2582,7 +2582,7 @@ c radius
      & 'm')
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
-c end define mode      
+c end define mode
       k=nf_enddef(idaqfile)
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
@@ -2632,7 +2632,7 @@ c
 
 ! Common blocks:
       common /cdf_var_jrat/ idjrat_rec,idvar_jrat(n_jrates+3),
-     &   idjratfile,ijratcount,jddim_jrat(4)      
+     &   idjratfile,ijratcount,jddim_jrat(4)
       integer idjrat_rec, idvar_jrat, idjratfile, ijratcount, jddim_jrat
 
 
@@ -2699,14 +2699,14 @@ c photolysis jrates
 c end define mode
        k=nf_enddef(idjratfile)
       if (k.ne.nf_noerr) call ehandle(k,fname)
- 
+
       end
 
 c
 c----------------------------------------------------------------
 c
 
-      subroutine open_rxn 
+      subroutine open_rxn
 c open netcdf file for reaction rates
 
       USE global_params, ONLY :
@@ -2719,7 +2719,7 @@ c open netcdf file for reaction rates
 ! Include statements:
       include 'netcdf.inc'
       common /cdf_var_rxn/ idrxn_rec,idvar_rxn(4),idrxnfile,
-     &   irxncount,jddim_rxn(4)      
+     &   irxncount,jddim_rxn(4)
       integer x,y,noz
 
       parameter (x=1,y=1,noz=1)
@@ -2789,7 +2789,7 @@ c reaction rates
 c end define mode
        k=nf_enddef(idrxnfile)
       if (k.ne.nf_noerr) call ehandle(k,fname)
- 
+
       end
 
 c
@@ -3106,7 +3106,7 @@ c
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=icount
-      
+
       field(1,1,:)=eta(1:n)
       k=nf_put_vara_double(idfile,idvar_g(1),idimstart,idimcount,field)
       if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -3121,7 +3121,7 @@ c
       field2(:,1,1)=enw(1:nka)
       k=nf_put_vara_double(idfile,idvar_g(3),idimstart,idimcount,field2)
       if (k.ne.nf_noerr) call ehandle(k,fname)
-      
+
       field2(:,1,1)=en(1:nka)
       k=nf_put_vara_double(idfile,idvar_g(4),idimstart,idimcount,field2)
       if (k.ne.nf_noerr) call ehandle(k,fname)
@@ -3172,14 +3172,14 @@ c close file
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end
-      
+
 
 
 c
 c----------------------------------------------------------------
 c
 
-      subroutine write_met (n_bln) 
+      subroutine write_met (n_bln)
 c output of meteorological variables
 
 ! jjb work done
@@ -3241,7 +3241,7 @@ c output of meteorological variables
       common /lang/ fl1(nrlev),fl2(nrlev),fln(nrlev),dtdtl(nrlay)
       double precision fl1, fl2, fln, dtdtl
 
-      dimension ifield(1,1,1), idimcount(4), idimstart(4) 
+      dimension ifield(1,1,1), idimcount(4), idimstart(4)
 !      dimension field(1,1,n),field2(4,1,n),blowitup(n) ! jjb field2 not used
       dimension field(1,1,n_bln),blowitup(n)
       dimension fd_u(n),fd_v(n),fd_q(n),fd_t(n),fd_tke(n)
@@ -3257,7 +3257,7 @@ c output of meteorological variables
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=icount
-      
+
 c time variables
       ifield(1,1,1)=lday
       k=nf_put_vara_int(idfile,idvar(1),idimstart,idimcount,ifield)
@@ -3327,8 +3327,8 @@ c other variables
       field(1,1,:)=rho(1:n_bln)
       k=nf_put_vara_double(idfile,idvar(14),idimstart,idimcount,field)
       if (k.ne.nf_noerr) call ehandle(k,fname)
-      
-c the next 3 variables are necessary to be f(t)/f(z) for comfortable plotting 
+
+c the next 3 variables are necessary to be f(t)/f(z) for comfortable plotting
 c in Ferret: they have to have same dimensions as vars to be plotted
       field(1,1,:)=eta(1:n_bln)
       k=nf_put_vara_double(idfile,idvar(15),idimstart,idimcount,field)
@@ -3486,7 +3486,7 @@ c
 
       common /oneDs/  partN(n,nkt,2),partr(n,nkt),drp(nkt)
 
-      dimension ifield(1,1,1), idimcount(4), idimstart(4), 
+      dimension ifield(1,1,1), idimcount(4), idimstart(4),
 !     &   field(nka,nkt,nf/10),field2(2,nkt,nf),
      &   field(nka,nkt,n/10),field2(2,nkt,nf), ! jjb test, see also below
      &   field3(1,nkt,nf)
@@ -3503,7 +3503,7 @@ c
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=imiccount
-      
+
 c time variables
       ifield(1,1,1)=lday
       k=nf_put_vara_int(idmicfile,idvar_mic(1),idimstart,
@@ -3565,8 +3565,8 @@ c time variables
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end subroutine write_mic
-      
-      
+
+
 c
 c----------------------------------------------------------------
 c
@@ -3585,13 +3585,8 @@ c
      &     j1,
      &     j5,
 ! Imported Array Variables with intent (in):
-     &     ind_gas,
      &     s1,
      &     s3
-
-      USE global_params, ONLY :
-! Imported Parameters:
-     &     n
 
       USE cdf_var_gas, ONLY :
      &     idgasfile,
@@ -3638,7 +3633,7 @@ c
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=igascount
-      
+
 c time variables
       ifield(1,1,1)=lday
       k=nf_put_vara_int(idgasfile,idvar_gas(1),idimstart,
@@ -3664,7 +3659,7 @@ c chemical species
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=igascount
-c offset due to time variables      
+c offset due to time variables
       i0 = j0
 
 c write all defined species
@@ -3690,8 +3685,8 @@ c radicals
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end subroutine write_chem_gas
-      
-      
+
+
 c
 c----------------------------------------------------------------
 c
@@ -3740,7 +3735,7 @@ c
 
 c add mercury/Hg
 
-c this lists which indices are defined and can be output - this HAS to be the same as in 
+c this lists which indices are defined and can be output - this HAS to be the same as in
 c SR open_chem_aq
 c "normal" aqueous phase species plus "normal" uncharged additional species
       data mliq /1,2,3,4,5,6,7,15,16,17,19,20,21,35,36,37,60,70,78,88,
@@ -3790,7 +3785,7 @@ c I ions
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=iliqcount
-      
+
 c time variables
       ifield(1,1,1)=lday
 c      k=nf_put_var1_int(idfile,idvar(1),icount,lday)
@@ -3971,8 +3966,8 @@ c
 
       common /band_rat/ photol_j(47,n)
 !      dimension field(1,1,n),jddim1(4),idimcount(4),idimstart(4), ! jjb jddim not used
-!     &        ifield(1,1,1) 
-      dimension field(1,1,n_bln),idimcount(4),idimstart(4),ifield(1,1,1) 
+!     &        ifield(1,1,1)
+      dimension field(1,1,n_bln),idimcount(4),idimstart(4),ifield(1,1,1)
       ijratcount=ijratcount+1
       fname="jrate.nc"
 
@@ -3985,7 +3980,7 @@ c
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=ijratcount
-      
+
 c time variables
       ifield(1,1,1)=lday
       k=nf_put_vara_int(idjratfile,idvar_jrat(1),idimstart,
@@ -4044,14 +4039,14 @@ c
 !     character*10 fname ! jjb
       character (len=30) fname ! jjb increased to be consistent with ehandle subroutine
       common /cdf_var_rxn/ idrxn_rec,idvar_rxn(4),idrxnfile,
-     &   irxncount,jddim_rxn(4) 
+     &   irxncount,jddim_rxn(4)
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
       double precision time
       integer lday, lst, lmin, it, lcl, lct
 
       common /budg/ bg(2,nrxn,nlev),il(nlev)
       dimension ifield(1,1,1),idimcount(4),idimstart(4),
-     &     field(1,nrxn,nlev) 
+     &     field(1,nrxn,nlev)
 
       fname="rxnrate.nc"
       irxncount=irxncount+1
@@ -4065,7 +4060,7 @@ c
       idimstart(2)=1
       idimstart(3)=1
       idimstart(4)=irxncount
-      
+
 c time variables
       ifield(1,1,1)=lday
       k=nf_put_vara_int(idrxnfile,idvar_rxn(1),idimstart,
@@ -4309,7 +4304,7 @@ c
 c
 c----------------------------------------------------------------
 c
-      
+
       subroutine close_mic
 
 ! Include statements:
@@ -4325,7 +4320,7 @@ c
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end subroutine close_mic
-      
+
 c
 c----------------------------------------------------------------
 c
@@ -4396,7 +4391,7 @@ c
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end subroutine close_jrate
-   
+
 c----------------------------------------------------------------
 c
 
@@ -4406,7 +4401,7 @@ c
       include 'netcdf.inc'
 
       common /cdf_var_rxn/ idrxn_rec,idvar_rxn(4),idrxnfile,
-     &   irxncount,jddim_rxn(4) 
+     &   irxncount,jddim_rxn(4)
 !     character*10 fname ! jjb
       character (len=30) fname ! jjb increased to be consistent with ehandle subroutine
       fname="rxnrate.nc"
@@ -4414,7 +4409,7 @@ c
       if (k.ne.nf_noerr) call ehandle(k,fname)
 
       end subroutine close_rxn
-       
+
 c
 c----------------------------------------------------------------
 c
@@ -4452,7 +4447,7 @@ c
       implicit none
 
 ! Include statements:
-      include 'netcdf.inc'  
+      include 'netcdf.inc'
 
       integer :: nb_err
       character (len=*) :: file

--- a/src/outp.f
+++ b/src/outp.f
@@ -18,10 +18,10 @@
 
 
 ! outp.f : output
-! box: the initial (const*) and overview (prof*) output SRs are not adjusted, 
-!      i.e. they produce a heap of output that's irrelevant. To avoid huge 
+! box: the initial (const*) and overview (prof*) output SRs are not adjusted,
+!      i.e. they produce a heap of output that's irrelevant. To avoid huge
 !     output files, the size of the plou* SRs has been adjusted by using
-!     n_bl and n_bln. Output starts at k=1 to save the deposited/surface 
+!     n_bl and n_bln. Output starts at k=1 to save the deposited/surface
 !     values as well.
 
 ! This file contains the following subroutines:
@@ -108,7 +108,7 @@
       common /cb47/ zb(nb),dzb(nb),dzbw(nb),tb(nb),eb(nb),ak(nb),d(nb),
      &              ajb,ajq,ajl,ajt,ajd,ajs,ds1,ds2,ajm,reif,tau,trdep
       real (kind=dp) :: zb, dzb, dzbw, tb, eb, ak, d,
-     &      ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
+     &     ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
       common /cb48/ sk,sl,dtrad(n),dtcon(n)
       double precision sk, sl, dtrad, dtcon
 
@@ -160,7 +160,7 @@
 ! integer single vars
      &     it,lcl,lct,lday,lmin,lst
       close (15)
- 
+
       end subroutine outm
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -323,8 +323,7 @@
       double precision xday,xst,xmin
 
 ! Local arrays:
-      double precision i0                    ! the local array where are written the photolysis rates,
-      dimension i0(nphrxn,n_bln) !    up to the selected level (1:n_bln)
+      double precision i0(nphrxn,n_bln)   ! the local array where are written the photolysis rates, up to the selected level (1:n_bln)
 
 ! Common blocks:
       common /band_rat/ photol_j(nphrxn,n)
@@ -393,7 +392,7 @@
 !   43. HOBr   44. BrNO2  45. BrNO3   46. Br2    47. BrCl    48. HI
 !   49. HOI    50. I2O2   51. INO2    52. INO3   53. I2      54. ICl
 !   55. IBr    56. CH3I   57. CH2I2   58. CH2ClI 59. C3H7I   60. DMSO
-!   61. CH3SO2 62. CH3SO3 63. CH3SO3H 64. CO     65. Cl2O2   66. DMOO    
+!   61. CH3SO2 62. CH3SO3 63. CH3SO3H 64. CO     65. Cl2O2   66. DMOO
 !   67. CH3S   68. CH3SO  69. MSIA    70. DMSO2  71. CH2BrI  72. CHBr2I
 !   73. C2H5I  74. HIO3   75. NUCV    76. SO3    77. HOSO2   78. CO2
 !   79. I2O    80. I2O3   81. I2O4    82. I2O5   83. INO     84. Br2O
@@ -442,8 +441,7 @@
       integer j,k, nmax
 
 ! Local arrays:
-      double precision i0
-      dimension i0(n_bl,j1)
+      double precision i0(n_bl,j1)
 
 ! Common blocks:
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
@@ -492,8 +490,8 @@
 !   11. O2-     12. NO2-    13. NO3-    14. Cl-       15. Cl2-
 !   16. HCOO-   17. Fe3+    18. Mn2+    19. HSO4-     20. Na+ (check electroneg)
 !   21. NO4-    22. ClO-    23. ClOH-   24. Br-       25. Br2-
-!   26. BrO-    27. BrOH-   28. BrCl2-  29. Br2Cl-    30. CH3SO3-     
-!   31. HSO5-   32. SO3-    33. SO5-    34. I-        35. IO2-        
+!   26. BrO-    27. BrOH-   28. BrCl2-  29. Br2Cl-    30. CH3SO3-
+!   31. HSO5-   32. SO3-    33. SO5-    34. I-        35. IO2-
 !   36. IO3-    37. ICl2-   38. IBr2-   39. MS-       40. Hg+
 !   41. Hg2+    42. HgOH+   43. HgCl+   44. HgCl3-    45. HgCl42-
 !   46. HgBr+   47. HgBr3-  48. HgBr42- 49. Hg(SO3)22- 50. --
@@ -537,8 +535,7 @@
       character (len=10) fname
 
 ! Local arrays:
-      double precision i0
-      dimension i0(n_bl,j6,nkc_l)
+      double precision i0(n_bl,j6,nkc_l)
 
 ! Common blocks:
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
@@ -598,7 +595,7 @@
 !   43. HOBr   44. BrNO2  45. BrNO3   46. Br2    47. BrCl    48. HI
 !   49. HOI    50. I2O2   51. INO2    52. INO3   53. I2      54. ICl
 !   55. IBr    56. CH3I   57. CH2I2   58. CH2ClI 59. C3H7I   60. DMSO
-!   61. CH3SO2 62. CH3SO3 63. CH3SO3H 64. CO     65. Cl2O2   66. DMOO    
+!   61. CH3SO2 62. CH3SO3 63. CH3SO3H 64. CO     65. Cl2O2   66. DMOO
 !   67. CH3S   68. CH3SO  69. MSIA    70. DMSO2  71. CH2BrI  72. CHBr2I
 !   73. C2H5I  74. HIO3   75. NUCV    76. SO3    77. HOSO2   78. CO2
 !   79. I2O    80. I2O3   81. I2O4    82. I2O5   83. INO     84. Br2O
@@ -645,7 +642,7 @@
 ! Imported Parameters:
      &     dp
 
- 
+
       implicit double precision (a-h,o-z)
 
 ! Subroutine arguments
@@ -658,27 +655,26 @@
       integer i,j,k, nmax
 
 ! Local arrays:
-      double precision i0,irc,icw
-      dimension i0(n_bl,j2,nkc_l),irc(n_bl,nkc_l),icw(n_bl,nkc_l)
+      double precision i0(n_bl,j2,nkc_l),irc(n_bl,nkc_l),icw(n_bl,nkc_l)
 
 ! Common blocks:
       common /blck11/ rc(nkc,n)
       common /blck12/ cw(nkc,n),cm(nkc,n)
       common /blck17/ sl1(j2,nkc,n),sion1(j6,nkc,n)
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
-      double precision time
-      integer lday, lst, lmin, it, lcl, lct
+      real (kind=dp) :: time
+      integer :: lday, lst, lmin, it, lcl, lct
 
       common /cb41/ detw(n),deta(n),eta(n),etw(n)
-      double precision detw, deta, eta, etw
+      real (kind=dp) :: detw, deta, eta, etw
 
       common /cb50/ enw(nka),ew(nkt),rn(nka),rw(nkt,nka),en(nka),
      &              e(nkt),dew(nkt),rq(nkt,nka)
-      double precision enw,ew,rn,rw,en,e,dew,rq
+      real (kind=dp) :: enw,ew,rn,rw,en,e,dew,rq
 
       common /cb52/ ff(nkt,nka,n),fsum(n),nar(n)
-      double precision ff, fsum
-      integer nar
+      real (kind=dp) :: ff, fsum
+      integer :: nar
 
 !- End of header ---------------------------------------------------------------
 
@@ -715,7 +711,7 @@
          do k=1,n_bl
             irc(k,kc)=rc(kc,k) ! jjb this transposition is maybe useless, just to stick to old write
             icw(k,kc)=cw(kc,k)
-         enddo      
+         enddo
       enddo
  3000 continue
       open (63, file=fname,status='old',form='unformatted',
@@ -732,7 +728,7 @@
 
 
 ! output of radical species s3:
-! species 1-3 are treated as long lived 
+! species 1-3 are treated as long lived
 !    1. ----    2. ----    3. ---     4. OH      5. HO2
 !    6. AHO2    7. MCO3    8. CH3OO   9. ETO2   10. KO2
 !   11. R3O2   12. RAO2   13. TO2    14. TCO3   15. ZO2
@@ -965,7 +961,7 @@
       common /cb47/ zb(nb),dzb(nb),dzbw(nb),tb(nb),eb(nb),ak(nb),d(nb),
      &              ajb,ajq,ajl,ajt,ajd,ajs,ds1,ds2,ajm,reif,tau,trdep
       real (kind=dp) :: zb, dzb, dzbw, tb, eb, ak, d,
-     &      ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
+     &     ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
       common /cb48/ sk,sl,dtrad(n),dtcon(n)
       double precision sk, sl, dtrad, dtcon
 
@@ -978,8 +974,7 @@
       common /cb54/ xm1(n),xm2(n),feu(n),dfddt(n),xm1a(n),xm2a(n)
       real(kind=dp) :: xm1, xm2, feu, dfddt, xm1a, xm2a
 
-      double precision i0
-      dimension i0(12,n_bln)
+      double precision i0(12,n_bln)
       character *10 fname
       character *1 fogtype
       do k=1,n_bln
@@ -1039,7 +1034,10 @@
 ! Imported Parameters:
      &     dp
 
-      double precision xm1,xm2,feu,dfddt,xm1a,xm2a
+      implicit none
+
+      integer :: kk, ia, jt, k     ! loop indexes
+      real (kind=dp) :: x0, x1, x2
 
       common /cb40/ time,lday,lst,lmin,it,lcl,lct
       double precision time
@@ -1055,7 +1053,7 @@
       common /cb54/ xm1(n),xm2(n),feu(n),dfddt(n),xm1a(n),xm2a(n)
       real(kind=dp) :: xm1, xm2, feu, dfddt, xm1a, xm2a
 
-      dimension ff2(nka,nkt)
+      real(kind=dp) :: ff2(nka,nkt)
       character *10 fname
       character *1 fogtype
       fname='f1 .out'
@@ -1181,8 +1179,7 @@
       common /lang/ fl1(nrlev),fl2(nrlev),fln(nrlev),dtdtl(nrlay)
       double precision fl1, fl2, fln, dtdtl
 
-      double precision i0
-      dimension i0(12,n_bln)
+      double precision i0(12,n_bln)
       character *10 fname
       character *1 fogtype
       do k=1,n_bln
@@ -1247,7 +1244,7 @@
       USE global_params, ONLY :
 ! Imported Parameters:
      &     n
-      
+
       USE precision, ONLY :
 ! Imported Parameters:
      &     dp
@@ -1273,8 +1270,7 @@
       common /cb45/ u(n),v(n),w(n)
       real (kind=dp) :: u, v, w
 
-      real (kind=dp) :: i0
-      dimension i0(12,n_bln)
+      real (kind=dp) :: i0(12,n_bln)
       character *10 fname
       character *1 fogtype
       do k=1,n_bln
@@ -1340,6 +1336,7 @@
       common /blck06/ kw(nka),ka
       common /cb18/ alat,declin                ! for the SZA calculation
       real (kind=dp) :: alat,declin
+      real (kind=dp) :: xsum(n)
 
       common /cb41/ detw(n),deta(n),eta(n),etw(n)
       real (kind=dp) :: detw, deta, eta, etw
@@ -1352,7 +1349,7 @@
       common /cb47/ zb(nb),dzb(nb),dzbw(nb),tb(nb),eb(nb),ak(nb),d(nb),
      &              ajb,ajq,ajl,ajt,ajd,ajs,ds1,ds2,ajm,reif,tau,trdep
       real (kind=dp) :: zb, dzb, dzbw, tb, eb, ak, d,
-     &      ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
+     &     ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
       common /cb50/ enw(nka),ew(nkt),rn(nka),rw(nkt,nka),en(nka),
      &              e(nkt),dew(nkt),rq(nkt,nka)
       real (kind=dp) :: enw,ew,rn,rw,en,e,dew,rq
@@ -1364,7 +1361,6 @@
       real (kind=dp) :: ff, fsum
       integer :: nar
 
-      dimension xsum(n)
       write (26,6000)
  6000 format (16x,'constants and parameters of the current run'
      & ,///,6x,'numerical grid',/,6x,'eta:')
@@ -1451,7 +1447,7 @@
          xsum(k)=xsum(k)*1.e+09
          xxsum=xxsum+xsum(k)*detw(k)
       enddo
-      write (26,6240) 
+      write (26,6240)
  6240 format (/,6x,'aerosol mass in ug m**-3 in layers 2 - nf')
       write (26,6250) xsum
  6250 format (1x,15f8.3)
@@ -1576,7 +1572,7 @@
       common /cb47/ zb(nb),dzb(nb),dzbw(nb),tb(nb),eb(nb),ak(nb),d(nb),
      &              ajb,ajq,ajl,ajt,ajd,ajs,ds1,ds2,ajm,reif,tau,trdep
       real (kind=dp) :: zb, dzb, dzbw, tb, eb, ak, d,
-     &      ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
+     &     ajb, ajq, ajl, ajt, ajd, ajs, ds1, ds2, ajm, reif, tau, trdep
       common /cb48/ sk,sl,dtrad(n),dtcon(n)
       double precision sk, sl, dtrad, dtcon
 
@@ -1594,7 +1590,7 @@
       real(kind=dp) :: xm1, xm2, feu, dfddt, xm1a, xm2a
 
       character *10 srname
-      dimension xsum(n)
+      real(kind=dp) :: xsum(n)
       srname='          '
       write (26,6000) it,dt,lday,lst,lmin
  6000 format (//,6x,i8,'-th. timestep dt = ',f4.1,' sec ',i2,' day ',
@@ -1616,7 +1612,7 @@
       xxm1=0.
       xxm2=0.
       do k=1,n
-!         xxm1=xm1(k)*detw(k)+xxm1    
+!         xxm1=xm1(k)*detw(k)+xxm1
          xxm1=xm1(k)*detw(k)*rho(k)*1000+xxm1
          xxm2=xm2(k)*detw(k)*1000+xxm2
 ! xxm1 in g/m**2 vapour content of atm., xxm2 in g/m**2 liquid water content of atm.
@@ -1659,7 +1655,7 @@
          xsum(k)=xsum(k)*1.e+09
          xxsum=xxsum+xsum(k)*detw(k)
       enddo
-      write (26,6240) 
+      write (26,6240)
  6240 format (/,6x,'aerosol mass in ug m**-3 in layers 2 - nf')
       write (26,6250) xsum
  6250 format (1x,15f8.3)
@@ -1670,7 +1666,7 @@
 ! 142  format (6x,9d12.4)
 
       call ion_mass (srname)
-      
+
 !      do k=2,nf
 !         do kc=1,nkc_l
 !            write (*,141) (k,kc,(dss(k,l,kc),l=1,lsp))
@@ -1857,7 +1853,7 @@
      &           bg(2,l,2)/am3(il(2)),bg(1,l,2)/am3(il(2))
      &           ,bg(2,l,3)/am3(il(3)),bg(1,l,3)/am3(il(3))
          enddo
-! 6170 format (//,'reaction rates integrated over 1 hour, converted to' 
+! 6170 format (//,'reaction rates integrated over 1 hour, converted to'
  6170 format (//,'accumulated reaction rates [mol/(m^3(air) s)]')
  6180 format (/,'height = ',19x,f10.2,' m',4x,f10.2,' m',4x,f10.2,' m')
 
@@ -1906,7 +1902,7 @@
      & sion1(13,kc,k)*xfac(k),sion1(21,kc,k),k=nf,1,-1)
  6020 format (f10.1,10e10.3)
  1033 continue
-      
+
       write (60,*) 'done with profc'
 
       end subroutine profc
@@ -2031,7 +2027,7 @@
  6020 format (/,'#layer',38x,'totrad(l,i) l=7,18 (IR)')
  6021 format (i4,12f10.3)
 
- 6030 format (/,'#level',4x,'pres',4x,'temp',10x'fs1',10x,'fs2',12x,
+ 6030 format (/,'#level',4x,'pres',4x,'temp',10x,'fs1',10x,'fs2',12x,
      &          'ss',11x,'fl1',11x,'fl2')
  6031 format(i4,f10.1,f8.1,5f14.3)
 

--- a/src/str.f90
+++ b/src/str.f90
@@ -1875,6 +1875,10 @@ end block data
      &     nkt, &
      &     nkc
 
+      USE precision, ONLY : &
+! Imported Parameters:
+           dp
+
       implicit double precision (a-h,o-z)
 !      double precision dt,f,fsum,c,psi,detw,deta,eta,etw
 
@@ -5126,6 +5130,10 @@ end block data
 ! Imported Parameters:
      &     nf, &
      &     n
+
+      USE precision, ONLY : &
+! Imported Parameters:
+           dp
 
       implicit double precision (a-h,o-z)
       logical BL_box


### PR DESCRIPTION
Following explicit declaration of common block variables, using real (kind=dp), a few references to dp in precision module were missing. Also a few declarations in outp.f were exceeding the 72nd character.

Cosmetic cleaning (remove blank at the end of lines)
Remove "dimension" attribute following the coding good practice suggested in this document: http://www.umr-cnrm.fr/gmapdoc/IMG/pdf/coding-rules.pdf
Improve param file: move the output files (*.nc, ...) in OUTDIR