### PR TITLE
Rephrase the presentation of CREDITS file

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -4,8 +4,7 @@ The main developers are:
 - Andreas Bott
 - Roland von Glasow
 
-List of authors of all known publications about MISTRA by alphabetical order.
-All people listed below contributed to various extent, without being necessary involved in the model code development.
+Below are listed all co-authors of papers dealing with previous versions of MISTRA that were published until 2015.
 
 - Aiuppa, A.
 - Allen, A. G.


### PR DESCRIPTION
This file contains the list of all co-authors of papers dealing with previous versions of MISTRA published until 2015